### PR TITLE
feat: add central .NET SDK synchronization workflow

### DIFF
--- a/.github/workflows/dotnet-sdk-sync.yml
+++ b/.github/workflows/dotnet-sdk-sync.yml
@@ -1,9 +1,6 @@
 name: Sync .NET SDK versions
 
 on:
-  push:
-    branches:
-      - feat/dotnet-sdk-sync-workflow
   schedule:
     # 09:00 America/Sao_Paulo (12:00 UTC), every Monday.
     - cron: "0 12 * * 1"
@@ -41,7 +38,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
-          DRY_RUN: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
         run: |
           set -Eeuo pipefail
 

--- a/.github/workflows/dotnet-sdk-sync.yml
+++ b/.github/workflows/dotnet-sdk-sync.yml
@@ -27,9 +27,9 @@ jobs:
     steps:
       - name: Create GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOTNET_SDK_SYNC_APP_ID }}
+          client-id: ${{ vars.DOTNET_SDK_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOTNET_SDK_SYNC_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/dotnet-sdk-sync.yml
+++ b/.github/workflows/dotnet-sdk-sync.yml
@@ -1,0 +1,290 @@
+name: Sync .NET SDK versions
+
+on:
+  schedule:
+    # 09:00 America/Sao_Paulo (12:00 UTC), every Monday.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Only report available updates; do not create branches or PRs"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-sdk-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Discover global.json and open update PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.DOTNET_SDK_SYNC_APP_ID }}
+          private-key: ${{ secrets.DOTNET_SDK_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Synchronize .NET SDK versions
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: |
+          set -Eeuo pipefail
+
+          readonly RELEASE_INDEX_URL="https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
+          readonly UPDATE_BRANCH="chore/sync-dotnet-sdk"
+
+          release_index="$(mktemp)"
+          repositories_file="$(mktemp)"
+
+          cleanup() {
+            rm -f "$release_index" "$repositories_file"
+          }
+          trap cleanup EXIT
+
+          curl --fail --silent --show-error --location             "$RELEASE_INDEX_URL"             --output "$release_index"
+
+          jq -e '.["releases-index"] | type == "array"' "$release_index" >/dev/null
+
+          gh api --paginate "/installation/repositories?per_page=100"             --jq '.repositories[] | [.full_name, .default_branch, (.archived | tostring), (.fork | tostring)] | @tsv'             > "$repositories_file"
+
+          repositories_scanned=0
+          repositories_with_global_json=0
+          repositories_current=0
+          repositories_with_updates=0
+          pull_requests_created=0
+          repositories_skipped=0
+          files_updated=0
+
+          {
+            echo "# .NET SDK synchronization"
+            echo
+            echo "Source: `$RELEASE_INDEX_URL`"
+            echo
+            echo "| Repository | Result |"
+            echo "| --- | --- |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS=$'\t' read -r repo default_branch archived fork; do
+            [[ -z "$repo" ]] && continue
+            [[ "$repo" != "$OWNER/"* ]] && continue
+
+            if [[ "$archived" == "true" || "$fork" == "true" ]]; then
+              repositories_skipped=$((repositories_skipped + 1))
+              printf '| `%s` | Skipped (archived or fork) |\n' "$repo" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            repositories_scanned=$((repositories_scanned + 1))
+
+            default_sha="$(gh api "repos/$repo/branches/$default_branch" --jq '.commit.sha')"
+            tree_sha="$(gh api "repos/$repo/git/commits/$default_sha" --jq '.tree.sha')"
+
+            global_json_paths="$(mktemp)"
+            updates_file="$(mktemp)"
+
+            gh api "repos/$repo/git/trees/$tree_sha?recursive=1"               --jq '.tree[]
+                | select(.type == "blob")
+                | select(.path == "global.json" or (.path | endswith("/global.json")))
+                | .path'               > "$global_json_paths"
+
+            if [[ ! -s "$global_json_paths" ]]; then
+              rm -f "$global_json_paths" "$updates_file"
+              printf '| `%s` | No global.json |\n' "$repo" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            repositories_with_global_json=$((repositories_with_global_json + 1))
+
+            while IFS= read -r path; do
+              [[ -z "$path" ]] && continue
+
+              file_response="$(gh api "repos/$repo/contents/$path?ref=$default_branch")"
+              content="$(jq -r '.content' <<< "$file_response" | tr -d '\n' | base64 --decode)"
+
+              if ! jq -e . >/dev/null 2>&1 <<< "$content"; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "INVALID_JSON" "-" "-" >> "$updates_file"
+                continue
+              fi
+
+              current="$(jq -r '.sdk.version // empty' <<< "$content")"
+
+              if [[ -z "$current" ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "NO_SDK_VERSION" "-" "-" >> "$updates_file"
+                continue
+              fi
+
+              # Preview SDKs are intentionally not managed by this workflow.
+              if [[ "$current" == *-* ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "PREVIEW" "$current" "-" >> "$updates_file"
+                continue
+              fi
+
+              channel="$(awk -F. '{ print $1 "." $2 }' <<< "$current")"
+
+              metadata="$(
+                jq -r --arg channel "$channel" '
+                  .["releases-index"][]
+                  | select(.["channel-version"] == $channel)
+                  | select(
+                      .["support-phase"] == "active"
+                      or .["support-phase"] == "maintenance"
+                    )
+                  | [
+                      .["latest-sdk"],
+                      .["release-type"],
+                      .["support-phase"]
+                    ]
+                  | @tsv
+                ' "$release_index" | head -n 1
+              )"
+
+              if [[ -z "$metadata" ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "UNSUPPORTED_CHANNEL" "$current" "-" >> "$updates_file"
+                continue
+              fi
+
+              IFS=$'\t' read -r latest release_type support_phase <<< "$metadata"
+
+              if [[ -z "$latest" || "$latest" == *-* ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "NO_STABLE_SDK" "$current" "-" >> "$updates_file"
+                continue
+              fi
+
+              if [[ "$current" == "$latest" ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "CURRENT" "$current" "$latest" >> "$updates_file"
+                continue
+              fi
+
+              highest="$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -n 1)"
+              if [[ "$highest" == "$current" ]]; then
+                printf '%s\t%s\t%s\t%s\n' "$path" "CURRENT_OR_NEWER" "$current" "$latest" >> "$updates_file"
+                continue
+              fi
+
+              printf '%s\t%s\t%s\t%s\n' "$path" "UPDATE" "$current" "$latest" >> "$updates_file"
+            done < "$global_json_paths"
+
+            update_count="$(awk -F'\t' '$2 == "UPDATE" { count++ } END { print count + 0 }' "$updates_file")"
+
+            if [[ "$update_count" -eq 0 ]]; then
+              repositories_current=$((repositories_current + 1))
+
+              status="$(
+                awk -F'\t' '
+                  $2 == "UNSUPPORTED_CHANNEL" { unsupported = 1 }
+                  $2 == "PREVIEW" { preview = 1 }
+                  $2 == "INVALID_JSON" { invalid = 1 }
+                  END {
+                    if (invalid) print "No update (invalid global.json)"
+                    else if (unsupported) print "No update (unsupported channel)"
+                    else if (preview) print "No update (preview SDK)"
+                    else print "Current"
+                  }
+                ' "$updates_file"
+              )"
+
+              printf '| `%s` | %s |\n' "$repo" "$status" >> "$GITHUB_STEP_SUMMARY"
+              rm -f "$global_json_paths" "$updates_file"
+              continue
+            fi
+
+            repositories_with_updates=$((repositories_with_updates + 1))
+            files_updated=$((files_updated + update_count))
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+              details="$(awk -F'\t' '$2 == "UPDATE" { printf "%s: %s → %s; ", $1, $3, $4 }' "$updates_file")"
+              printf '| `%s` | Dry run — %s |\n' "$repo" "$details" >> "$GITHUB_STEP_SUMMARY"
+              rm -f "$global_json_paths" "$updates_file"
+              continue
+            fi
+
+            existing_pr="$(
+              gh pr list                 --repo "$repo"                 --state open                 --head "$UPDATE_BRANCH"                 --json number                 --jq '.[0].number // empty'
+            )"
+
+            if [[ -n "$existing_pr" ]]; then
+              printf '| `%s` | Update available; PR #%s already open |\n' "$repo" "$existing_pr" >> "$GITHUB_STEP_SUMMARY"
+              rm -f "$global_json_paths" "$updates_file"
+              continue
+            fi
+
+            # Remove only the workflow-owned branch when it is stale and has no open PR.
+            if gh api "repos/$repo/git/ref/heads/$UPDATE_BRANCH" >/dev/null 2>&1; then
+              gh api                 --method DELETE                 "repos/$repo/git/refs/heads/$UPDATE_BRANCH"                 >/dev/null
+            fi
+
+            gh api               --method POST               "repos/$repo/git/refs"               -f ref="refs/heads/$UPDATE_BRANCH"               -f sha="$default_sha"               >/dev/null
+
+            while IFS=$'\t' read -r path status current latest; do
+              [[ "$status" != "UPDATE" ]] && continue
+
+              branch_file_response="$(gh api "repos/$repo/contents/$path?ref=$UPDATE_BRANCH")"
+              file_sha="$(jq -r '.sha' <<< "$branch_file_response")"
+              branch_content="$(jq -r '.content' <<< "$branch_file_response" | tr -d '\n' | base64 --decode)"
+              updated_content="$(jq --arg version "$latest" '.sdk.version = $version' <<< "$branch_content")"
+              encoded_content="$(printf '%s\n' "$updated_content" | base64 --wrap=0)"
+
+              gh api                 --method PUT                 "repos/$repo/contents/$path"                 -f message="chore: update .NET SDK from $current to $latest"                 -f content="$encoded_content"                 -f sha="$file_sha"                 -f branch="$UPDATE_BRANCH"                 >/dev/null
+            done < "$updates_file"
+
+            pr_body="$(mktemp)"
+            {
+              echo "## .NET SDK update"
+              echo
+              echo "This PR was created automatically by the central .NET SDK synchronization workflow."
+              echo
+              echo "| File | Current SDK | Latest supported SDK |"
+              echo "| --- | ---: | ---: |"
+
+              while IFS=$'\t' read -r path status current latest; do
+                [[ "$status" != "UPDATE" ]] && continue
+                printf '| `%s` | `%s` | `%s` |\n' "$path" "$current" "$latest"
+              done < "$updates_file"
+
+              echo
+              echo "### Policy"
+              echo
+              echo "- Updates remain within the existing .NET `major.minor` channel."
+              echo "- Preview SDKs are ignored."
+              echo "- Channels outside active/maintenance support are not upgraded automatically."
+              echo "- Major/minor migrations require an explicit repository-level decision."
+              echo
+              echo "Release metadata source: `$RELEASE_INDEX_URL`"
+            } > "$pr_body"
+
+            pr_url="$(
+              gh pr create                 --repo "$repo"                 --base "$default_branch"                 --head "$UPDATE_BRANCH"                 --title "chore: update .NET SDK"                 --body-file "$pr_body"
+            )"
+
+            pull_requests_created=$((pull_requests_created + 1))
+            printf '| `%s` | PR created: %s |\n' "$repo" "$pr_url" >> "$GITHUB_STEP_SUMMARY"
+
+            rm -f "$pr_body" "$global_json_paths" "$updates_file"
+          done < "$repositories_file"
+
+          {
+            echo
+            echo "## Summary"
+            echo
+            echo "| Metric | Count |"
+            echo "| --- | ---: |"
+            echo "| Repositories scanned | $repositories_scanned |"
+            echo "| Repositories with global.json | $repositories_with_global_json |"
+            echo "| Repositories already current / no automatic update | $repositories_current |"
+            echo "| Repositories with updates | $repositories_with_updates |"
+            echo "| Files requiring updates | $files_updated |"
+            echo "| Pull requests created | $pull_requests_created |"
+            echo "| Repositories skipped | $repositories_skipped |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dotnet-sdk-sync.yml
+++ b/.github/workflows/dotnet-sdk-sync.yml
@@ -1,6 +1,9 @@
 name: Sync .NET SDK versions
 
 on:
+  push:
+    branches:
+      - feat/dotnet-sdk-sync-workflow
   schedule:
     # 09:00 America/Sao_Paulo (12:00 UTC), every Monday.
     - cron: "0 12 * * 1"
@@ -38,7 +41,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          DRY_RUN: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
         run: |
           set -Eeuo pipefail
 


### PR DESCRIPTION
## Summary

Adds a central GitHub Actions workflow to keep .NET SDK versions in `global.json` files up to date across repositories accessible to a dedicated GitHub App.

## Behavior

- runs every Monday at 09:00 America/Sao_Paulo and supports manual execution;
- enumerates repositories available to the GitHub App installation;
- searches recursively for `global.json`;
- reads the current `sdk.version`;
- checks Microsoft's official .NET release metadata;
- updates only within the same `major.minor` channel;
- ignores preview SDKs;
- skips unsupported channels instead of performing major/minor migrations;
- avoids duplicate PRs using a workflow-owned branch;
- supports a manual `dry_run`;
- writes an execution summary to the GitHub Actions job summary.

## Required configuration

Create a GitHub App installed on the repositories that should participate, with at least:

- **Contents:** Read & write
- **Pull requests:** Read & write
- **Metadata:** Read

Then configure in this repository:

- repository variable: `DOTNET_SDK_SYNC_APP_CLIENT_ID`
- repository secret: `DOTNET_SDK_SYNC_APP_PRIVATE_KEY`

The workflow intentionally does not auto-merge SDK updates; each target repository's existing CI and branch protection remain responsible for validating the generated PR.