### PR TITLE
fix: prevent Markdown backticks from executing in SDK sync

### DIFF
--- a/.github/workflows/dotnet-sdk-sync.yml
+++ b/.github/workflows/dotnet-sdk-sync.yml
@@ -70,7 +70,7 @@ jobs:
           {
             echo "# .NET SDK synchronization"
             echo
-            echo "Source: `$RELEASE_INDEX_URL`"
+            printf 'Source: `%s`\n' "$RELEASE_INDEX_URL"
             echo
             echo "| Repository | Result |"
             echo "| --- | --- |"
@@ -256,12 +256,12 @@ jobs:
               echo
               echo "### Policy"
               echo
-              echo "- Updates remain within the existing .NET `major.minor` channel."
+              echo '- Updates remain within the existing .NET `major.minor` channel.'
               echo "- Preview SDKs are ignored."
               echo "- Channels outside active/maintenance support are not upgraded automatically."
               echo "- Major/minor migrations require an explicit repository-level decision."
               echo
-              echo "Release metadata source: `$RELEASE_INDEX_URL`"
+              printf 'Release metadata source: `%s`\n' "$RELEASE_INDEX_URL"
             } > "$pr_body"
 
             pr_url="$(


### PR DESCRIPTION
## Summary

Fixes shell command-substitution caused by Markdown backticks inside double-quoted `echo` statements in the .NET SDK synchronization workflow.

The dry-run execution exposed this log entry:

```
https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json: No such file or directory
```

The URL was not missing; Bash was interpreting the Markdown backticks as command substitution.

## Changes

- render the release metadata URL with `printf`;
- use single quotes for static Markdown containing backticks;
- preserve the existing workflow behavior and dry-run semantics.

This also prevents the same issue from occurring later when the workflow generates PR descriptions.