### PR TITLE
feat: add central .NET repository inventory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+*.md text eol=lf diff=markdown
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.code-workspace text eol=lf
+
+.gitattributes text eol=lf
+.gitignore text eol=lf

--- a/.github.code-workspace
+++ b/.github.code-workspace
@@ -1,0 +1,27 @@
+{
+  "folders": [
+    {
+      "name": ".github",
+      "path": "."
+    }
+  ],
+  "settings": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "files.eol": "\n",
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true,
+    "markdown.extension.toc.levels": "2..3",
+    "yaml.schemas": {
+      "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.{yml,yaml}",
+      "https://json.schemastore.org/github-funding.json": ".github/FUNDING.yml"
+    }
+  },
+  "extensions": {
+    "recommendations": [
+      "github.vscode-github-actions",
+      "redhat.vscode-yaml",
+      "davidanson.vscode-markdownlint"
+    ]
+  }
+}

--- a/.github/workflows/dotnet-repository-inventory.yml
+++ b/.github/workflows/dotnet-repository-inventory.yml
@@ -1,0 +1,482 @@
+name: Inventory .NET repositories
+
+on:
+  schedule:
+    # 09:30 America/Sao_Paulo (12:30 UTC), every Wednesday.
+    - cron: "30 12 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dotnet-repository-inventory
+  cancel-in-progress: false
+
+jobs:
+  inventory:
+    name: Inspect accessible .NET repositories
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.DOTNET_SDK_SYNC_APP_CLIENT_ID }}
+          private-key: ${{ secrets.DOTNET_SDK_SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: read
+          permission-metadata: read
+
+      - name: Checkout DotNetRepoInspector
+        uses: actions/checkout@v4
+        with:
+          repository: rodri-oliveira-dev/DotNetRepoInspector
+          ref: main
+          path: .inspector
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+
+      - name: Build DotNetRepoInspector
+        shell: bash
+        env:
+          DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+          DOTNET_NOLOGO: "1"
+          INSPECTOR_PROJECT: ${{ github.workspace }}/.inspector/src/DotNetRepoInspector.Cli/DotNetRepoInspector.Cli.csproj
+        run: |
+          set -Eeuo pipefail
+
+          dotnet restore "$INSPECTOR_PROJECT"
+          dotnet build "$INSPECTOR_PROJECT" --configuration Release --no-restore
+
+      - name: Generate .NET repository inventory
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+          INSPECTOR_PROJECT: ${{ github.workspace }}/.inspector/src/DotNetRepoInspector.Cli/DotNetRepoInspector.Cli.csproj
+          DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+          DOTNET_NOLOGO: "1"
+        run: |
+          # shellcheck disable=SC2016
+          set -Eeuo pipefail
+
+          readonly INSPECTOR_REPOSITORY="rodri-oliveira-dev/DotNetRepoInspector"
+          readonly INSPECTOR_REF="main"
+
+          mkdir -p "$ARTIFACTS_DIR"
+
+          repositories_file="$(mktemp)"
+          repositories_jsonl="$(mktemp)"
+          projects_jsonl="$(mktemp)"
+          workspace_root="$(mktemp -d)"
+
+          cleanup() {
+            rm -f "$repositories_file" "$repositories_jsonl" "$projects_jsonl"
+            rm -rf "$workspace_root"
+          }
+          trap cleanup EXIT
+
+          append_repository() {
+            local repository="$1"
+            local visibility="$2"
+            local default_branch="$3"
+            local status="$4"
+            local csproj_count="$5"
+            local message="$6"
+
+            jq -cn \
+              --arg repository "$repository" \
+              --arg visibility "$visibility" \
+              --arg default_branch "$default_branch" \
+              --arg status "$status" \
+              --argjson csproj_count "$csproj_count" \
+              --arg message "$message" \
+              '{
+                repository: $repository,
+                visibility: $visibility,
+                default_branch: $default_branch,
+                status: $status,
+                csproj_count: $csproj_count,
+                message: $message
+              }' >> "$repositories_jsonl"
+          }
+
+          append_project_fallback() {
+            local repository="$1"
+            local visibility="$2"
+            local default_branch="$3"
+            local project_path="$4"
+            local status="$5"
+
+            local project_file
+            local project_name
+            project_file="${project_path##*/}"
+            project_name="${project_file%.csproj}"
+
+            jq -cn \
+              --arg repository "$repository" \
+              --arg visibility "$visibility" \
+              --arg default_branch "$default_branch" \
+              --arg project_path "$project_path" \
+              --arg project_name "$project_name" \
+              --arg status "$status" \
+              '{
+                repository: $repository,
+                visibility: $visibility,
+                default_branch: $default_branch,
+                project_path: $project_path,
+                project_name: $project_name,
+                classification: "unknown",
+                target_frameworks: [],
+                project_sdk: "",
+                configured_dotnet_sdk: "",
+                resolved_dotnet_sdk: "",
+                is_test: false,
+                is_packable: false,
+                output_type: "",
+                status: $status,
+                diagnostics: []
+              }' >> "$projects_jsonl"
+          }
+
+          append_projects_from_report() {
+            local repository="$1"
+            local visibility="$2"
+            local default_branch="$3"
+            local exit_code="$4"
+            local report_file="$5"
+
+            jq -c \
+              --arg repository "$repository" \
+              --arg visibility "$visibility" \
+              --arg default_branch "$default_branch" \
+              --argjson exit_code "$exit_code" '
+              def text_or_empty(value): value // "";
+              . as $report
+              | ($report.dotNetSdk.configured.version // "") as $configured_sdk
+              | ($report.dotNetSdk.resolvedVersion // "") as $repo_resolved_sdk
+              | $report.projects[]?
+              | ([
+                  .diagnostics[]?.severity,
+                  (if $exit_code == 0 then empty else "warning" end)
+                ] | map((. // "") | ascii_downcase)) as $severities
+              | {
+                  repository: $repository,
+                  visibility: $visibility,
+                  default_branch: $default_branch,
+                  project_path: text_or_empty(.path),
+                  project_name: text_or_empty(.name),
+                  classification: (.classification.kind // "unknown"),
+                  target_frameworks: (.targetFrameworks // []),
+                  project_sdk: ((.sdks // []) | map(.name // empty) | join("; ")),
+                  configured_dotnet_sdk: $configured_sdk,
+                  resolved_dotnet_sdk: (.resolvedSdkVersion // $repo_resolved_sdk // ""),
+                  is_test: (.isTestProject // false),
+                  is_packable: (.isPackable // false),
+                  output_type: text_or_empty(.outputType),
+                  status: (
+                    if any($severities[]; . == "error") then "error"
+                    elif any($severities[]; . == "warning") then "warning"
+                    else "ok"
+                    end
+                  ),
+                  diagnostics: (.diagnostics // [])
+                }' "$report_file" >> "$projects_jsonl"
+          }
+
+          write_summary_markdown() {
+            local inventory_json="$1"
+
+            {
+              echo "# .NET repository inventory"
+              echo
+              printf 'Inspector: `%s@%s`\n' "$INSPECTOR_REPOSITORY" "$INSPECTOR_REF"
+              echo
+              echo "| Repository | Project | Type | Target Framework | SDK |"
+              echo "| --- | --- | --- | --- | --- |"
+
+              jq -r '
+                def md:
+                  tostring
+                  | gsub("\r|\n"; " ")
+                  | gsub("\\|"; "\\|");
+                def sdk:
+                  if (.configured_dotnet_sdk == "" and .resolved_dotnet_sdk == "") then ""
+                  elif (.configured_dotnet_sdk == "") then ("resolved " + .resolved_dotnet_sdk)
+                  elif (.resolved_dotnet_sdk == "" or .resolved_dotnet_sdk == .configured_dotnet_sdk) then .configured_dotnet_sdk
+                  else (.configured_dotnet_sdk + " -> " + .resolved_dotnet_sdk)
+                  end;
+                .projects[]
+                | [
+                    .repository,
+                    (.project_path // .project_name // ""),
+                    .classification,
+                    ((.target_frameworks // []) | join("<br>")),
+                    sdk
+                  ]
+                | "| " + (map(md) | join(" | ")) + " |"
+              ' "$inventory_json"
+
+              echo
+              echo "## Summary"
+              echo
+              echo "| Metric | Count |"
+              echo "| --- | ---: |"
+              jq -r '
+                .summary
+                | [
+                    ["Repositories scanned", .repositories_scanned],
+                    ["Repositories with .NET projects", .repositories_with_dotnet_projects],
+                    ["Repositories without .NET projects", .repositories_without_dotnet_projects],
+                    ["Total .NET projects", .total_dotnet_projects],
+                    ["Web projects", .web_projects],
+                    ["Worker projects", .worker_projects],
+                    ["Console projects", .console_projects],
+                    ["Library projects", .library_projects],
+                    ["Test projects", .test_projects],
+                    ["Unknown projects", .unknown_projects],
+                    ["Inspection warnings/errors", .inspection_warnings_errors]
+                  ][]
+                | "| \(.[0]) | \(.[1]) |"
+              ' "$inventory_json"
+            } >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          gh api --paginate "/installation/repositories?per_page=100" \
+            --jq '
+              .repositories[]
+              | [
+                  .full_name,
+                  (.owner.login // ""),
+                  (.visibility // (if .private then "private" else "public" end)),
+                  (.default_branch // ""),
+                  (.archived | tostring),
+                  (.fork | tostring)
+                ]
+              | @tsv
+            ' > "$repositories_file"
+
+          repositories_scanned=0
+          repositories_with_dotnet_projects=0
+          repositories_without_dotnet_projects=0
+          inspection_warnings_errors=0
+
+          while IFS=$'\t' read -r repository repository_owner visibility default_branch archived fork; do
+            [[ -z "$repository" ]] && continue
+            [[ "$repository_owner" != "$OWNER" ]] && continue
+            [[ "$archived" == "true" || "$fork" == "true" ]] && continue
+
+            repositories_scanned=$((repositories_scanned + 1))
+
+            if [[ -z "$default_branch" ]]; then
+              inspection_warnings_errors=$((inspection_warnings_errors + 1))
+              append_repository "$repository" "$visibility" "$default_branch" "missing_default_branch" 0 "Repository does not expose a default branch."
+              echo "::warning title=Repository skipped::$repository does not expose a default branch."
+              continue
+            fi
+
+            repo_dir="$(mktemp -d "$workspace_root/repository.XXXXXX")"
+            csproj_paths_file="$(mktemp)"
+            inspected_paths_file="$(mktemp)"
+            missing_paths_file="$(mktemp)"
+            inspection_file="$(mktemp)"
+            inspector_stdout="$(mktemp)"
+            inspector_stderr="$(mktemp)"
+
+            rm -rf "$repo_dir"
+
+            if ! gh repo clone "$repository" "$repo_dir" -- --depth 1 --branch "$default_branch" --filter=blob:none --quiet; then
+              inspection_warnings_errors=$((inspection_warnings_errors + 1))
+              append_repository "$repository" "$visibility" "$default_branch" "clone_failed" 0 "Default branch could not be cloned."
+              echo "::warning title=Repository clone failed::Unable to clone $repository on $default_branch."
+              rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
+              rm -rf "$repo_dir"
+              continue
+            fi
+
+            (
+              cd "$repo_dir"
+              find . -type f -name '*.csproj' -not -path './.git/*' -printf '%P\n' | LC_ALL=C sort
+            ) > "$csproj_paths_file"
+
+            csproj_count="$(wc -l < "$csproj_paths_file" | tr -d '[:space:]')"
+
+            if [[ "$csproj_count" == "0" ]]; then
+              repositories_without_dotnet_projects=$((repositories_without_dotnet_projects + 1))
+              append_repository "$repository" "$visibility" "$default_branch" "no_dotnet_projects" 0 "No .csproj files found."
+              rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
+              rm -rf "$repo_dir"
+              continue
+            fi
+
+            repositories_with_dotnet_projects=$((repositories_with_dotnet_projects + 1))
+
+            set +e
+            env \
+              -u GH_TOKEN \
+              -u GITHUB_TOKEN \
+              -u ACTIONS_ID_TOKEN_REQUEST_TOKEN \
+              -u ACTIONS_RUNTIME_TOKEN \
+              dotnet run \
+                --project "$INSPECTOR_PROJECT" \
+                --configuration Release \
+                --no-build \
+                -- "$repo_dir" \
+                --output "$inspection_file" \
+                > "$inspector_stdout" \
+                2> "$inspector_stderr"
+            inspector_exit_code=$?
+            set -e
+
+            if [[ -s "$inspection_file" ]] && jq -e . "$inspection_file" >/dev/null 2>&1; then
+              append_projects_from_report "$repository" "$visibility" "$default_branch" "$inspector_exit_code" "$inspection_file"
+
+              jq -r '.projects[]?.path // empty' "$inspection_file" | LC_ALL=C sort > "$inspected_paths_file"
+              comm -23 "$csproj_paths_file" "$inspected_paths_file" > "$missing_paths_file"
+
+              while IFS= read -r project_path; do
+                [[ -z "$project_path" ]] && continue
+                append_project_fallback "$repository" "$visibility" "$default_branch" "$project_path" "not_inspected"
+              done < "$missing_paths_file"
+
+              diagnostic_count="$(
+                jq '
+                  [
+                    .diagnostics[]?,
+                    .projects[]?.diagnostics[]?
+                  ]
+                  | map(select((.severity // "" | ascii_downcase) == "warning" or (.severity // "" | ascii_downcase) == "error"))
+                  | length
+                ' "$inspection_file"
+              )"
+
+              if [[ "$diagnostic_count" != "0" ]]; then
+                inspection_warnings_errors=$((inspection_warnings_errors + diagnostic_count))
+                echo "::warning title=Repository inspection produced diagnostics::$repository produced $diagnostic_count warning/error diagnostic(s)."
+              elif [[ "$inspector_exit_code" != "0" ]]; then
+                inspection_warnings_errors=$((inspection_warnings_errors + 1))
+                echo "::warning title=Repository inspection returned non-zero::$repository inspection exited with code $inspector_exit_code."
+              fi
+
+              if [[ -s "$missing_paths_file" ]]; then
+                missing_count="$(wc -l < "$missing_paths_file" | tr -d '[:space:]')"
+                inspection_warnings_errors=$((inspection_warnings_errors + missing_count))
+                echo "::warning title=Project inspection incomplete::$repository has $missing_count .csproj file(s) not present in the Inspector report."
+              fi
+
+              append_repository "$repository" "$visibility" "$default_branch" "inspected" "$csproj_count" "Inspection completed."
+            else
+              inspection_warnings_errors=$((inspection_warnings_errors + 1))
+              echo "::warning title=Repository inspection failed::$repository inspection did not produce a valid JSON report."
+
+              while IFS= read -r project_path; do
+                [[ -z "$project_path" ]] && continue
+                append_project_fallback "$repository" "$visibility" "$default_branch" "$project_path" "inspection_failed"
+              done < "$csproj_paths_file"
+
+              append_repository "$repository" "$visibility" "$default_branch" "inspection_failed" "$csproj_count" "Inspection did not produce a valid JSON report."
+            fi
+
+            rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
+            rm -rf "$repo_dir"
+          done < "$repositories_file"
+
+          inventory_json="$ARTIFACTS_DIR/dotnet-repository-inventory.json"
+          inventory_csv="$ARTIFACTS_DIR/dotnet-repository-inventory.csv"
+
+          jq -n \
+            --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg owner "$OWNER" \
+            --arg inspector_repository "$INSPECTOR_REPOSITORY" \
+            --arg inspector_ref "$INSPECTOR_REF" \
+            --argjson repositories_scanned "$repositories_scanned" \
+            --argjson repositories_with_dotnet_projects "$repositories_with_dotnet_projects" \
+            --argjson repositories_without_dotnet_projects "$repositories_without_dotnet_projects" \
+            --argjson inspection_warnings_errors "$inspection_warnings_errors" \
+            --slurpfile repositories <(jq -s '.' "$repositories_jsonl") \
+            --slurpfile projects <(jq -s '.' "$projects_jsonl") \
+            '($projects[0] // []) as $project_rows
+            | {
+                generated_at: $generated_at,
+                owner: $owner,
+                source: {
+                  inspector_repository: $inspector_repository,
+                  inspector_ref: $inspector_ref
+                },
+                summary: {
+                  repositories_scanned: $repositories_scanned,
+                  repositories_with_dotnet_projects: $repositories_with_dotnet_projects,
+                  repositories_without_dotnet_projects: $repositories_without_dotnet_projects,
+                  total_dotnet_projects: ($project_rows | length),
+                  web_projects: ($project_rows | map(select(.classification == "web")) | length),
+                  worker_projects: ($project_rows | map(select(.classification == "worker")) | length),
+                  console_projects: ($project_rows | map(select(.classification == "console")) | length),
+                  library_projects: ($project_rows | map(select(.classification == "library")) | length),
+                  test_projects: ($project_rows | map(select(.classification == "test" or .is_test == true)) | length),
+                  unknown_projects: ($project_rows | map(select(.classification == "unknown")) | length),
+                  inspection_warnings_errors: $inspection_warnings_errors
+                },
+                repositories: ($repositories[0] // []),
+                projects: $project_rows
+              }' > "$inventory_json"
+
+          jq -r '
+            ([
+              "repository",
+              "visibility",
+              "default_branch",
+              "project_path",
+              "project_name",
+              "classification",
+              "target_frameworks",
+              "project_sdk",
+              "configured_dotnet_sdk",
+              "resolved_dotnet_sdk",
+              "is_test",
+              "is_packable",
+              "output_type",
+              "status"
+            ] | @csv),
+            (.projects[]
+              | [
+                  .repository,
+                  .visibility,
+                  .default_branch,
+                  .project_path,
+                  .project_name,
+                  .classification,
+                  ((.target_frameworks // []) | join("; ")),
+                  .project_sdk,
+                  .configured_dotnet_sdk,
+                  .resolved_dotnet_sdk,
+                  (.is_test | tostring),
+                  (.is_packable | tostring),
+                  .output_type,
+                  .status
+                ]
+              | @csv)
+          ' "$inventory_json" > "$inventory_csv"
+
+          jq -e . "$inventory_json" >/dev/null
+          test -s "$inventory_csv"
+
+          write_summary_markdown "$inventory_json"
+
+      - name: Upload inventory artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-repository-inventory
+          path: artifacts/
+          if-no-files-found: warn
+          retention-days: 3

--- a/.github/workflows/dotnet-repository-inventory.yml
+++ b/.github/workflows/dotnet-repository-inventory.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
+          CURRENT_REPOSITORY_PRIVATE: ${{ github.event.repository.private }}
           ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
           INSPECTOR_PROJECT: ${{ github.workspace }}/.inspector/src/DotNetRepoInspector.Cli/DotNetRepoInspector.Cli.csproj
           DOTNET_CLI_TELEMETRY_OPTOUT: "1"
@@ -72,6 +73,7 @@ jobs:
 
           readonly INSPECTOR_REPOSITORY="rodri-oliveira-dev/DotNetRepoInspector"
           readonly INSPECTOR_REF="main"
+          readonly INCLUDE_NON_PUBLIC_REPOSITORIES="$CURRENT_REPOSITORY_PRIVATE"
 
           mkdir -p "$ARTIFACTS_DIR"
 
@@ -275,6 +277,7 @@ jobs:
             [[ -z "$repository" ]] && continue
             [[ "$repository_owner" != "$OWNER" ]] && continue
             [[ "$archived" == "true" || "$fork" == "true" ]] && continue
+            [[ "$INCLUDE_NON_PUBLIC_REPOSITORIES" != "true" && "$visibility" != "public" ]] && continue
 
             repositories_scanned=$((repositories_scanned + 1))
 
@@ -399,6 +402,7 @@ jobs:
             --arg owner "$OWNER" \
             --arg inspector_repository "$INSPECTOR_REPOSITORY" \
             --arg inspector_ref "$INSPECTOR_REF" \
+            --argjson include_non_public_repositories "$INCLUDE_NON_PUBLIC_REPOSITORIES" \
             --argjson repositories_scanned "$repositories_scanned" \
             --argjson repositories_with_dotnet_projects "$repositories_with_dotnet_projects" \
             --argjson repositories_without_dotnet_projects "$repositories_without_dotnet_projects" \
@@ -411,7 +415,8 @@ jobs:
                 owner: $owner,
                 source: {
                   inspector_repository: $inspector_repository,
-                  inspector_ref: $inspector_ref
+                  inspector_ref: $inspector_ref,
+                  include_non_public_repositories: $include_non_public_repositories
                 },
                 summary: {
                   repositories_scanned: $repositories_scanned,

--- a/.github/workflows/dotnet-repository-inventory.yml
+++ b/.github/workflows/dotnet-repository-inventory.yml
@@ -78,12 +78,14 @@ jobs:
           mkdir -p "$ARTIFACTS_DIR"
 
           repositories_file="$(mktemp)"
+          eligible_repositories_file="$(mktemp)"
           repositories_jsonl="$(mktemp)"
           projects_jsonl="$(mktemp)"
+          problems_jsonl="$(mktemp)"
           workspace_root="$(mktemp -d)"
 
           cleanup() {
-            rm -f "$repositories_file" "$repositories_jsonl" "$projects_jsonl"
+            rm -f "$repositories_file" "$eligible_repositories_file" "$repositories_jsonl" "$projects_jsonl" "$problems_jsonl"
             rm -rf "$workspace_root"
           }
           trap cleanup EXIT
@@ -111,6 +113,68 @@ jobs:
                 csproj_count: $csproj_count,
                 message: $message
               }' >> "$repositories_jsonl"
+          }
+
+          append_problem() {
+            local repository="$1"
+            local stage="$2"
+            local message="$3"
+
+            jq -cn \
+              --arg repository "$repository" \
+              --arg stage "$stage" \
+              --arg message "$message" \
+              '{
+                repository: $repository,
+                stage: $stage,
+                message: $message
+              }' >> "$problems_jsonl"
+          }
+
+          record_problem() {
+            local repository="$1"
+            local stage="$2"
+            local message="$3"
+
+            append_problem "$repository" "$stage" "$message"
+
+            if [[ "$repository_had_problem" == "0" ]]; then
+              repository_had_problem=1
+              repositories_with_warnings_errors=$((repositories_with_warnings_errors + 1))
+            fi
+          }
+
+          cleanup_repository() {
+            local cleanup_failed=0
+
+            rm -f \
+              "$csproj_paths_file" \
+              "$inspected_paths_file" \
+              "$missing_paths_file" \
+              "$inspection_file" \
+              "$inspector_stdout" \
+              "$inspector_stderr" || cleanup_failed=1
+
+            rm -rf "$repo_dir" || cleanup_failed=1
+
+            if [[ "$cleanup_failed" == "1" ]]; then
+              record_problem "$repository" "cleanup" "Temporary files could not be fully removed."
+              echo "::warning title=Repository cleanup failed::Temporary files for $repository could not be fully removed."
+            fi
+          }
+
+          print_repository_result() {
+            local position="$1"
+            local total="$2"
+            local status="$3"
+            local repository="$4"
+            local message="$5"
+
+            if [[ "$repository_had_problem" == "1" && "$status" == "OK" ]]; then
+              status="WARNING"
+            fi
+
+            printf '[%s/%s] %-9s %s - %s\n' "$position" "$total" "$status" "$repository" "$message"
           }
 
           append_project_fallback() {
@@ -237,9 +301,12 @@ jobs:
               jq -r '
                 .summary
                 | [
+                    ["Repositories planned", .repositories_planned],
+                    ["Repositories processed", .repositories_processed],
                     ["Repositories scanned", .repositories_scanned],
                     ["Repositories with .NET projects", .repositories_with_dotnet_projects],
                     ["Repositories without .NET projects", .repositories_without_dotnet_projects],
+                    ["Repositories with warnings/errors", .repositories_with_warnings_errors],
                     ["Total .NET projects", .total_dotnet_projects],
                     ["Web projects", .web_projects],
                     ["Worker projects", .worker_projects],
@@ -251,6 +318,29 @@ jobs:
                   ][]
                 | "| \(.[0]) | \(.[1]) |"
               ' "$inventory_json"
+
+              echo
+              echo "## Inspection problems"
+              echo
+              if jq -e '(.problems // []) | length > 0' "$inventory_json" >/dev/null; then
+                echo "| Repository | Stage | Problem |"
+                echo "| --- | --- | --- |"
+                jq -r '
+                  def md:
+                    tostring
+                    | gsub("\r|\n"; " ")
+                    | gsub("\\|"; "\\|");
+                  .problems[]
+                  | [
+                      .repository,
+                      .stage,
+                      .message
+                    ]
+                  | "| " + (map(md) | join(" | ")) + " |"
+                ' "$inventory_json"
+              else
+                echo "No repository-level inspection problems were detected."
+              fi
             } >> "$GITHUB_STEP_SUMMARY"
           }
 
@@ -268,23 +358,43 @@ jobs:
               | @tsv
             ' > "$repositories_file"
 
+          awk -v owner="$OWNER" -v include_non_public="$INCLUDE_NON_PUBLIC_REPOSITORIES" -F '\t' '
+            $1 != "" &&
+            $2 == owner &&
+            $5 != "true" &&
+            $6 != "true" &&
+            (include_non_public == "true" || $3 == "public")
+          ' "$repositories_file" > "$eligible_repositories_file"
+
+          repositories_planned="$(wc -l < "$eligible_repositories_file" | tr -d '[:space:]')"
           repositories_scanned=0
+          repositories_processed=0
           repositories_with_dotnet_projects=0
           repositories_without_dotnet_projects=0
+          repositories_with_warnings_errors=0
           inspection_warnings_errors=0
 
-          while IFS=$'\t' read -r repository repository_owner visibility default_branch archived fork; do
-            [[ -z "$repository" ]] && continue
-            [[ "$repository_owner" != "$OWNER" ]] && continue
-            [[ "$archived" == "true" || "$fork" == "true" ]] && continue
-            [[ "$INCLUDE_NON_PUBLIC_REPOSITORIES" != "true" && "$visibility" != "public" ]] && continue
+          echo ".NET repository inventory"
+          echo "Eligible repositories: $repositories_planned"
+          echo "Starting repository inspection..."
 
-            repositories_scanned=$((repositories_scanned + 1))
+          while IFS=$'\t' read -r repository _repository_owner visibility default_branch _archived _fork; do
+            [[ -z "$repository" ]] && continue
+
+            repositories_processed=$((repositories_processed + 1))
+            repositories_scanned=$repositories_processed
+            repository_had_problem=0
+            repository_position="$repositories_processed"
+            default_branch_display="${default_branch:-<none>}"
+
+            printf '[%s/%s] Inspecting %s (branch: %s)\n' "$repository_position" "$repositories_planned" "$repository" "$default_branch_display"
 
             if [[ -z "$default_branch" ]]; then
+              record_problem "$repository" "discovery" "Repository does not expose a default branch."
               inspection_warnings_errors=$((inspection_warnings_errors + 1))
               append_repository "$repository" "$visibility" "$default_branch" "missing_default_branch" 0 "Repository does not expose a default branch."
               echo "::warning title=Repository skipped::$repository does not expose a default branch."
+              print_repository_result "$repository_position" "$repositories_planned" "FAILED" "$repository" "missing default branch"
               continue
             fi
 
@@ -299,11 +409,12 @@ jobs:
             rm -rf "$repo_dir"
 
             if ! gh repo clone "$repository" "$repo_dir" -- --depth 1 --branch "$default_branch" --filter=blob:none --quiet; then
+              record_problem "$repository" "clone" "Default branch could not be cloned."
               inspection_warnings_errors=$((inspection_warnings_errors + 1))
               append_repository "$repository" "$visibility" "$default_branch" "clone_failed" 0 "Default branch could not be cloned."
               echo "::warning title=Repository clone failed::Unable to clone $repository on $default_branch."
-              rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
-              rm -rf "$repo_dir"
+              cleanup_repository
+              print_repository_result "$repository_position" "$repositories_planned" "FAILED" "$repository" "clone failed"
               continue
             fi
 
@@ -317,8 +428,8 @@ jobs:
             if [[ "$csproj_count" == "0" ]]; then
               repositories_without_dotnet_projects=$((repositories_without_dotnet_projects + 1))
               append_repository "$repository" "$visibility" "$default_branch" "no_dotnet_projects" 0 "No .csproj files found."
-              rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
-              rm -rf "$repo_dir"
+              cleanup_repository
+              print_repository_result "$repository_position" "$repositories_planned" "NO-DOTNET" "$repository" "no .csproj files"
               continue
             fi
 
@@ -364,23 +475,42 @@ jobs:
               )"
 
               if [[ "$diagnostic_count" != "0" ]]; then
+                record_problem "$repository" "inspection" "Inspector reported $diagnostic_count warning/error diagnostic(s)."
                 inspection_warnings_errors=$((inspection_warnings_errors + diagnostic_count))
                 echo "::warning title=Repository inspection produced diagnostics::$repository produced $diagnostic_count warning/error diagnostic(s)."
-              elif [[ "$inspector_exit_code" != "0" ]]; then
+              fi
+
+              if [[ "$inspector_exit_code" != "0" ]]; then
+                record_problem "$repository" "inspection" "Inspector exited with code $inspector_exit_code."
                 inspection_warnings_errors=$((inspection_warnings_errors + 1))
                 echo "::warning title=Repository inspection returned non-zero::$repository inspection exited with code $inspector_exit_code."
               fi
 
               if [[ -s "$missing_paths_file" ]]; then
                 missing_count="$(wc -l < "$missing_paths_file" | tr -d '[:space:]')"
+                record_problem "$repository" "report" "$missing_count .csproj file(s) were not present in the Inspector report."
                 inspection_warnings_errors=$((inspection_warnings_errors + missing_count))
                 echo "::warning title=Project inspection incomplete::$repository has $missing_count .csproj file(s) not present in the Inspector report."
               fi
 
               append_repository "$repository" "$visibility" "$default_branch" "inspected" "$csproj_count" "Inspection completed."
+              cleanup_repository
+
+              if [[ "$repository_had_problem" == "1" ]]; then
+                print_repository_result "$repository_position" "$repositories_planned" "WARNING" "$repository" "inspection completed with problem(s)"
+              else
+                print_repository_result "$repository_position" "$repositories_planned" "OK" "$repository" "$csproj_count project(s)"
+              fi
             else
+              record_problem "$repository" "report" "Inspector did not produce a valid JSON report."
               inspection_warnings_errors=$((inspection_warnings_errors + 1))
               echo "::warning title=Repository inspection failed::$repository inspection did not produce a valid JSON report."
+
+              if [[ "$inspector_exit_code" != "0" ]]; then
+                record_problem "$repository" "inspection" "Inspector exited with code $inspector_exit_code."
+                inspection_warnings_errors=$((inspection_warnings_errors + 1))
+                echo "::warning title=Repository inspection returned non-zero::$repository inspection exited with code $inspector_exit_code."
+              fi
 
               while IFS= read -r project_path; do
                 [[ -z "$project_path" ]] && continue
@@ -388,11 +518,10 @@ jobs:
               done < "$csproj_paths_file"
 
               append_repository "$repository" "$visibility" "$default_branch" "inspection_failed" "$csproj_count" "Inspection did not produce a valid JSON report."
+              cleanup_repository
+              print_repository_result "$repository_position" "$repositories_planned" "FAILED" "$repository" "invalid or missing Inspector report"
             fi
-
-            rm -f "$csproj_paths_file" "$inspected_paths_file" "$missing_paths_file" "$inspection_file" "$inspector_stdout" "$inspector_stderr"
-            rm -rf "$repo_dir"
-          done < "$repositories_file"
+          done < "$eligible_repositories_file"
 
           inventory_json="$ARTIFACTS_DIR/dotnet-repository-inventory.json"
           inventory_csv="$ARTIFACTS_DIR/dotnet-repository-inventory.csv"
@@ -403,12 +532,16 @@ jobs:
             --arg inspector_repository "$INSPECTOR_REPOSITORY" \
             --arg inspector_ref "$INSPECTOR_REF" \
             --argjson include_non_public_repositories "$INCLUDE_NON_PUBLIC_REPOSITORIES" \
+            --argjson repositories_planned "$repositories_planned" \
+            --argjson repositories_processed "$repositories_processed" \
             --argjson repositories_scanned "$repositories_scanned" \
             --argjson repositories_with_dotnet_projects "$repositories_with_dotnet_projects" \
             --argjson repositories_without_dotnet_projects "$repositories_without_dotnet_projects" \
+            --argjson repositories_with_warnings_errors "$repositories_with_warnings_errors" \
             --argjson inspection_warnings_errors "$inspection_warnings_errors" \
             --slurpfile repositories <(jq -s '.' "$repositories_jsonl") \
             --slurpfile projects <(jq -s '.' "$projects_jsonl") \
+            --slurpfile problems <(jq -s '.' "$problems_jsonl") \
             '($projects[0] // []) as $project_rows
             | {
                 generated_at: $generated_at,
@@ -419,9 +552,12 @@ jobs:
                   include_non_public_repositories: $include_non_public_repositories
                 },
                 summary: {
+                  repositories_planned: $repositories_planned,
+                  repositories_processed: $repositories_processed,
                   repositories_scanned: $repositories_scanned,
                   repositories_with_dotnet_projects: $repositories_with_dotnet_projects,
                   repositories_without_dotnet_projects: $repositories_without_dotnet_projects,
+                  repositories_with_warnings_errors: $repositories_with_warnings_errors,
                   total_dotnet_projects: ($project_rows | length),
                   web_projects: ($project_rows | map(select(.classification == "web")) | length),
                   worker_projects: ($project_rows | map(select(.classification == "worker")) | length),
@@ -432,7 +568,8 @@ jobs:
                   inspection_warnings_errors: $inspection_warnings_errors
                 },
                 repositories: ($repositories[0] // []),
-                projects: $project_rows
+                projects: $project_rows,
+                problems: ($problems[0] // [])
               }' > "$inventory_json"
 
           jq -r '
@@ -474,6 +611,28 @@ jobs:
 
           jq -e . "$inventory_json" >/dev/null
           test -s "$inventory_csv"
+
+          total_dotnet_projects="$(jq -r '.summary.total_dotnet_projects' "$inventory_json")"
+
+          echo "=================================================="
+          echo ".NET repository inventory completed"
+          echo "=================================================="
+          echo
+          printf 'Repositories planned: %s\n' "$repositories_planned"
+          printf 'Repositories processed: %s\n' "$repositories_processed"
+          printf 'Repositories with .NET projects: %s\n' "$repositories_with_dotnet_projects"
+          printf 'Repositories without .NET projects: %s\n' "$repositories_without_dotnet_projects"
+          printf 'Repositories with warnings/errors: %s\n' "$repositories_with_warnings_errors"
+          printf 'Total .NET projects: %s\n' "$total_dotnet_projects"
+          echo
+
+          if [[ -s "$problems_jsonl" ]]; then
+            echo "Problems detected:"
+            echo
+            jq -r '"- \(.repository) | \(.stage) | \(.message)"' "$problems_jsonl"
+          else
+            echo "Problems detected: none"
+          fi
 
           write_summary_markdown "$inventory_json"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Generated workflow artifacts
+artifacts/
+
+# Local validation and temporary files
+.tmp-*/
+tmp/
+temp/
+*.tmp
+*.log
+
+# Local tool checkouts/build output
+.inspector/
+
+# Editor and OS files
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ The workflow keeps Target Framework and .NET SDK data separate. A Target Framewo
 
 The inventory runs manually through `workflow_dispatch` and weekly on Wednesdays at 09:30 in `America/Sao_Paulo` (12:30 UTC), avoiding the Monday schedule used by SDK synchronization. Concurrency prevents overlapping inventory runs.
 
-The GitHub Actions Summary is the primary visible report. It shows one Markdown table row per `.csproj`, including repository, project path, project type, Target Framework, and SDK, followed by counts for scanned repositories, repositories with and without .NET projects, total projects, classification totals, and inspection warnings/errors.
+The workflow log shows the eligible repository count before inspection starts, then prints per-repository progress in `[current/total]` format with a short final status for each repository. Isolated repository-level failures do not interrupt inspection of the remaining repositories.
+
+The GitHub Actions Summary is the primary visible report. It shows one Markdown table row per `.csproj`, including repository, project path, project type, Target Framework, and SDK, followed by counts for planned and processed repositories, repositories with and without .NET projects, total projects, classification totals, and inspection warnings/errors. Repository-level problems are also consolidated in the summary and at the end of the workflow log.
 
 The workflow also exports:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # .github
 
 [![Sync .NET SDK versions](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-sdk-sync.yml/badge.svg)](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-sdk-sync.yml)
+[![Inventory .NET repositories](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-repository-inventory.yml/badge.svg)](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-repository-inventory.yml)
 
 Central repository for shared community standards and maintenance automation across repositories maintained under the `rodri-oliveira-dev` account.
 
@@ -16,10 +17,14 @@ Repository-specific files always take precedence when a project needs different 
 
 | File / workflow | Purpose |
 | --- | --- |
+| [`.gitattributes`](.gitattributes) | Repository-local line-ending and diff normalization for documentation, JSON, and GitHub Actions workflow files. |
+| [`.gitignore`](.gitignore) | Repository-local ignore rules for generated artifacts, temporary validation files, local tool checkouts, and editor/OS files. |
+| [`.github.code-workspace`](.github.code-workspace) | VS Code workspace settings and extension recommendations for consistent Markdown, YAML, and GitHub Actions editing. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Default contribution guidelines, development workflow, Pull Request expectations, code-quality principles, and common .NET validation guidance. |
 | [`SECURITY.md`](SECURITY.md) | Default security policy, responsible vulnerability reporting, disclosure expectations, and scope. |
 | [`.github/FUNDING.yml`](.github/FUNDING.yml) | GitHub Sponsors configuration. |
 | [`.github/workflows/dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) | Central automation that checks repository-root `global.json` files and opens SDK update Pull Requests when appropriate. |
+| [`.github/workflows/dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) | Central read-only automation that inventories .NET projects across repositories accessible to the configured GitHub App. |
 
 ## How GitHub uses this repository
 
@@ -38,7 +43,9 @@ Examples of repository-specific overrides include:
 - codes of conduct;
 - build, testing, release, or compatibility requirements.
 
-## Central .NET SDK synchronization
+## Central .NET automations
+
+### .NET SDK synchronization
 
 The [`dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) workflow provides centralized SDK maintenance for repositories accessible to the configured GitHub App.
 
@@ -58,14 +65,48 @@ The scheduled run executes every Monday at 09:00 in `America/Sao_Paulo` (12:00 U
 
 This workflow is maintenance automation, not a default community-health file inherited automatically by other repositories. It actively evaluates repositories through the GitHub App installation and creates repository-level Pull Requests when an eligible SDK update exists.
 
+### .NET repository inventory
+
+The [`dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) workflow builds a consolidated, read-only inventory of .NET projects across repositories accessible to the configured GitHub App.
+
+It uses [`rodri-oliveira-dev/DotNetRepoInspector`](https://github.com/rodri-oliveira-dev/DotNetRepoInspector) as the source of truth for project inspection. Project classification is based on evaluated MSBuild metadata from the Inspector, not Bash heuristics or raw `.csproj` parsing.
+
+The inventory identifies these project types:
+
+- `web`;
+- `worker`;
+- `console`;
+- `library`;
+- `test`;
+- `unknown`.
+
+The workflow keeps Target Framework and .NET SDK data separate. A Target Framework such as `net10.0` describes what the project targets at compile/runtime level, while a configured or resolved .NET SDK such as `10.0.100` describes the SDK used to evaluate/build tooling for the repository.
+
+The inventory runs manually through `workflow_dispatch` and weekly on Wednesdays at 09:30 in `America/Sao_Paulo` (12:30 UTC), avoiding the Monday schedule used by SDK synchronization. Concurrency prevents overlapping inventory runs.
+
+The GitHub Actions Summary is the primary visible report. It shows one Markdown table row per `.csproj`, including repository, project path, project type, Target Framework, and SDK, followed by counts for scanned repositories, repositories with and without .NET projects, total projects, classification totals, and inspection warnings/errors.
+
+The workflow also exports:
+
+- `artifacts/dotnet-repository-inventory.csv`;
+- `artifacts/dotnet-repository-inventory.json`.
+
+Both files are uploaded as the `dotnet-repository-inventory` artifact with `retention-days: 3`, so they remain downloadable from the workflow run for 3 days.
+
+Repositories without `.csproj` files are counted and do not fail the run. Clone or inspection problems in individual repositories are recorded as warnings/status entries, and the consolidated report is still produced. The workflow uses the existing GitHub App credentials, requests only read permissions from GitHub Actions, ignores forks and archived repositories, inspects default branches only, removes per-repository temporary directories after inspection, and does not write to analyzed repositories.
+
 ## Repository structure
 
 ```text
 .
+├── .gitattributes
 ├── .github/
 │   ├── FUNDING.yml
 │   └── workflows/
+│       ├── dotnet-repository-inventory.yml
 │       └── dotnet-sdk-sync.yml
+├── .github.code-workspace
+├── .gitignore
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 ├── README.md
@@ -80,7 +121,7 @@ This repository follows a few simple governance principles:
 - **least privilege** — cross-repository automation uses a GitHub App with scoped permissions;
 - **review before change** — maintenance automation opens Pull Requests instead of merging directly;
 - **safe defaults** — version-management automation avoids implicit major/minor migrations;
-- **observable automation** — workflow results are exposed through GitHub Actions logs and summaries.
+- **observable automation** — workflow results are exposed through GitHub Actions logs, summaries, and short-lived artifacts when structured data is useful.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ This workflow is maintenance automation, not a default community-health file inh
 
 The [`dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) workflow builds a consolidated, read-only inventory of .NET projects across repositories accessible to the configured GitHub App.
 
+Because this repository is public, the workflow publishes only public repository metadata in its GitHub Actions Summary and downloadable artifacts. Non-public repositories accessible to the GitHub App are skipped before cloning or reporting so private repository names, paths, frameworks, and SDK versions are not exposed through public workflow runs. If the same workflow is moved to a private repository, it can include non-public repositories because the run output and artifacts inherit that repository's restricted visibility.
+
 It uses [`rodri-oliveira-dev/DotNetRepoInspector`](https://github.com/rodri-oliveira-dev/DotNetRepoInspector) as the source of truth for project inspection. Project classification is based on evaluated MSBuild metadata from the Inspector, not Bash heuristics or raw `.csproj` parsing.
 
 The inventory identifies these project types:
@@ -93,7 +95,7 @@ The workflow also exports:
 
 Both files are uploaded as the `dotnet-repository-inventory` artifact with `retention-days: 3`, so they remain downloadable from the workflow run for 3 days.
 
-Repositories without `.csproj` files are counted and do not fail the run. Clone or inspection problems in individual repositories are recorded as warnings/status entries, and the consolidated report is still produced. The workflow uses the existing GitHub App credentials, requests only read permissions from GitHub Actions, ignores forks and archived repositories, inspects default branches only, removes per-repository temporary directories after inspection, and does not write to analyzed repositories.
+Repositories without `.csproj` files are counted and do not fail the run. Clone or inspection problems in individual reported repositories are recorded as warnings/status entries, and the consolidated report is still produced. The workflow uses the existing GitHub App credentials, requests only read permissions from GitHub Actions, ignores forks and archived repositories, inspects default branches only, removes per-repository temporary directories after inspection, and does not write to analyzed repositories.
 
 ## Repository structure
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,6 +1,7 @@
 # .github
 
 [![Sincronizar versões do .NET SDK](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-sdk-sync.yml/badge.svg)](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-sdk-sync.yml)
+[![Inventariar repositórios .NET](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-repository-inventory.yml/badge.svg)](https://github.com/rodri-oliveira-dev/.github/actions/workflows/dotnet-repository-inventory.yml)
 
 Repositório central para padrões compartilhados de comunidade e automações de manutenção dos repositórios mantidos na conta `rodri-oliveira-dev`.
 
@@ -16,10 +17,14 @@ Arquivos específicos de cada repositório sempre têm prioridade quando um proj
 
 | Arquivo / workflow | Finalidade |
 | --- | --- |
+| [`.gitattributes`](.gitattributes) | Normalização local de quebras de linha e diff para documentação, JSON e workflows do GitHub Actions. |
+| [`.gitignore`](.gitignore) | Regras locais de ignore para artifacts gerados, arquivos temporários de validação, checkouts locais de ferramentas e arquivos de editor/SO. |
+| [`.github.code-workspace`](.github.code-workspace) | Configurações de workspace do VS Code e recomendações de extensões para edição consistente de Markdown, YAML e GitHub Actions. |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Diretrizes padrão para contribuição, fluxo de desenvolvimento, expectativas para Pull Requests, princípios de qualidade de código e orientações comuns de validação em .NET. |
 | [`SECURITY.md`](SECURITY.md) | Política padrão de segurança, reporte responsável de vulnerabilidades, expectativas de divulgação e escopo. |
 | [`.github/FUNDING.yml`](.github/FUNDING.yml) | Configuração do GitHub Sponsors. |
 | [`.github/workflows/dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) | Automação central que verifica arquivos `global.json` na raiz dos repositórios e abre Pull Requests de atualização do SDK quando aplicável. |
+| [`.github/workflows/dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) | Automação central somente leitura que inventaria projetos .NET nos repositórios acessíveis à GitHub App configurada. |
 
 ## Como o GitHub utiliza este repositório
 
@@ -38,7 +43,9 @@ Exemplos de regras que podem ser sobrescritas localmente:
 - código de conduta;
 - requisitos de build, testes, release ou compatibilidade.
 
-## Sincronização central do .NET SDK
+## Automações centrais de .NET
+
+### Sincronização central do .NET SDK
 
 O workflow [`dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) fornece manutenção centralizada de SDK para os repositórios acessíveis à GitHub App configurada.
 
@@ -58,14 +65,48 @@ A execução agendada ocorre toda segunda-feira às 09:00 em `America/Sao_Paulo`
 
 Esse workflow é uma automação de manutenção e não um arquivo de comunidade herdado automaticamente pelos demais repositórios. Ele consulta ativamente os repositórios através da instalação da GitHub App e cria Pull Requests individuais quando encontra uma atualização elegível do SDK.
 
+### Inventário central de repositórios .NET
+
+O workflow [`dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) gera um inventário consolidado, somente leitura, dos projetos .NET existentes nos repositórios acessíveis à GitHub App configurada.
+
+Ele usa [`rodri-oliveira-dev/DotNetRepoInspector`](https://github.com/rodri-oliveira-dev/DotNetRepoInspector) como fonte de verdade para inspeção dos projetos. A classificação é baseada em metadados MSBuild efetivos obtidos pelo Inspector, não em heurísticas Bash nem parsing direto de `.csproj`.
+
+O inventário identifica estes tipos de projeto:
+
+- `web`;
+- `worker`;
+- `console`;
+- `library`;
+- `test`;
+- `unknown`.
+
+O workflow mantém Target Framework e .NET SDK como conceitos separados. Um Target Framework como `net10.0` descreve o alvo de compilação/execução do projeto, enquanto um SDK configurado ou resolvido como `10.0.100` descreve o SDK usado pela avaliação/build tooling do repositório.
+
+O inventário pode ser executado manualmente por `workflow_dispatch` e também roda semanalmente às quartas-feiras, às 09:30 em `America/Sao_Paulo` (12:30 UTC), sem sobrepor o agendamento de segunda-feira da sincronização de SDK. A configuração de concorrência impede execuções simultâneas do inventário.
+
+O GitHub Actions Summary é o relatório visual principal. Ele mostra uma tabela Markdown com uma linha por `.csproj`, incluindo repositório, caminho do projeto, tipo, Target Framework e SDK, seguida por contagens de repositórios verificados, repositórios com e sem projetos .NET, total de projetos, totais por classificação e warnings/erros de inspeção.
+
+O workflow também exporta:
+
+- `artifacts/dotnet-repository-inventory.csv`;
+- `artifacts/dotnet-repository-inventory.json`.
+
+Os dois arquivos são enviados como artifact `dotnet-repository-inventory` com `retention-days: 3`, permanecendo disponíveis para download na execução do workflow por 3 dias.
+
+Repositórios sem arquivos `.csproj` são contabilizados e não fazem a execução falhar. Problemas de clone ou inspeção em repositórios individuais são registrados como warnings/status, e o relatório consolidado continua sendo produzido. O workflow reutiliza as credenciais existentes da GitHub App, solicita apenas permissões de leitura no GitHub Actions, ignora forks e repositórios arquivados, inspeciona somente a branch padrão, remove diretórios temporários de cada repositório após a inspeção e não escreve nos repositórios analisados.
+
 ## Estrutura do repositório
 
 ```text
 .
+├── .gitattributes
 ├── .github/
 │   ├── FUNDING.yml
 │   └── workflows/
+│       ├── dotnet-repository-inventory.yml
 │       └── dotnet-sdk-sync.yml
+├── .github.code-workspace
+├── .gitignore
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 ├── README.md
@@ -80,7 +121,7 @@ Este repositório segue alguns princípios simples:
 - **menor privilégio** — automações entre repositórios usam uma GitHub App com permissões restritas;
 - **revisão antes da alteração** — automações de manutenção abrem Pull Requests em vez de fazer merge direto;
 - **padrões seguros** — a automação de versões não realiza migrações implícitas de major/minor;
-- **automação observável** — os resultados dos workflows são registrados nos logs e summaries do GitHub Actions.
+- **automação observável** — os resultados dos workflows são registrados nos logs, summaries e artifacts de curta duração quando dados estruturados são úteis.
 
 ## Contribuição
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -86,7 +86,9 @@ O workflow mantém Target Framework e .NET SDK como conceitos separados. Um Targ
 
 O inventário pode ser executado manualmente por `workflow_dispatch` e também roda semanalmente às quartas-feiras, às 09:30 em `America/Sao_Paulo` (12:30 UTC), sem sobrepor o agendamento de segunda-feira da sincronização de SDK. A configuração de concorrência impede execuções simultâneas do inventário.
 
-O GitHub Actions Summary é o relatório visual principal. Ele mostra uma tabela Markdown com uma linha por `.csproj`, incluindo repositório, caminho do projeto, tipo, Target Framework e SDK, seguida por contagens de repositórios verificados, repositórios com e sem projetos .NET, total de projetos, totais por classificação e warnings/erros de inspeção.
+O log do workflow mostra a quantidade de repositórios elegíveis antes do início da inspeção e, em seguida, imprime o progresso por repositório no formato `[atual/total]`, com um status final curto para cada repositório. Falhas isoladas no nível de um repositório não interrompem a inspeção dos demais.
+
+O GitHub Actions Summary é o relatório visual principal. Ele mostra uma tabela Markdown com uma linha por `.csproj`, incluindo repositório, caminho do projeto, tipo, Target Framework e SDK, seguida por contagens de repositórios planejados e processados, repositórios com e sem projetos .NET, total de projetos, totais por classificação e warnings/erros de inspeção. Problemas no nível de repositório também são consolidados no summary e ao final do log do workflow.
 
 O workflow também exporta:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -69,6 +69,8 @@ Esse workflow é uma automação de manutenção e não um arquivo de comunidade
 
 O workflow [`dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) gera um inventário consolidado, somente leitura, dos projetos .NET existentes nos repositórios acessíveis à GitHub App configurada.
 
+Como este repositório é público, o workflow publica somente metadados de repositórios públicos no GitHub Actions Summary e nos artifacts baixáveis. Repositórios não públicos acessíveis à GitHub App são ignorados antes de clone ou relatório para que nomes de repositórios privados, caminhos, frameworks e versões de SDK não sejam expostos em execuções públicas. Se o mesmo workflow for movido para um repositório privado, ele pode incluir repositórios não públicos porque a saída da execução e os artifacts herdam a visibilidade restrita desse repositório.
+
 Ele usa [`rodri-oliveira-dev/DotNetRepoInspector`](https://github.com/rodri-oliveira-dev/DotNetRepoInspector) como fonte de verdade para inspeção dos projetos. A classificação é baseada em metadados MSBuild efetivos obtidos pelo Inspector, não em heurísticas Bash nem parsing direto de `.csproj`.
 
 O inventário identifica estes tipos de projeto:
@@ -93,7 +95,7 @@ O workflow também exporta:
 
 Os dois arquivos são enviados como artifact `dotnet-repository-inventory` com `retention-days: 3`, permanecendo disponíveis para download na execução do workflow por 3 dias.
 
-Repositórios sem arquivos `.csproj` são contabilizados e não fazem a execução falhar. Problemas de clone ou inspeção em repositórios individuais são registrados como warnings/status, e o relatório consolidado continua sendo produzido. O workflow reutiliza as credenciais existentes da GitHub App, solicita apenas permissões de leitura no GitHub Actions, ignora forks e repositórios arquivados, inspeciona somente a branch padrão, remove diretórios temporários de cada repositório após a inspeção e não escreve nos repositórios analisados.
+Repositórios sem arquivos `.csproj` são contabilizados e não fazem a execução falhar. Problemas de clone ou inspeção em repositórios individuais reportados são registrados como warnings/status, e o relatório consolidado continua sendo produzido. O workflow reutiliza as credenciais existentes da GitHub App, solicita apenas permissões de leitura no GitHub Actions, ignora forks e repositórios arquivados, inspeciona somente a branch padrão, remove diretórios temporários de cada repositório após a inspeção e não escreve nos repositórios analisados.
 
 ## Estrutura do repositório
 


### PR DESCRIPTION
## Summary
- Add a read-only GitHub Actions workflow to inventory .NET projects across repositories accessible to the configured GitHub App.
- Reuse DotNetRepoInspector for MSBuild-based metadata and project classification.
- Export CSV/JSON artifacts with 3-day retention and document the workflow in EN/PT-BR READMEs.
- Add repository standardization files: `.gitattributes`, `.gitignore`, and `.github.code-workspace`.

## Validation
- Parsed workflow YAML with PyYAML.
- Validated embedded Bash scripts with `bash -n`.
- Validated workspace JSON.
- Ran `git diff --check`.
- Ran a synthetic Docker exercise for inventory JSON, CSV, Step Summary, and partial-failure continuation.