### PR TITLE
feat: add reusable secret scanning workflow

### DIFF
--- a/.github/workflows/reusable-secret-scan.yml
+++ b/.github/workflows/reusable-secret-scan.yml
@@ -1,0 +1,263 @@
+name: Reusable secret scan
+
+on:
+  workflow_call:
+    outputs:
+      result:
+        description: "Secret scan result: clean, findings, or tool-failure."
+        value: ${{ jobs.secret-scan.outputs.result }}
+      scope:
+        description: "Scope used by the scanner: pull-request-diff, push-diff, or full-history."
+        value: ${{ jobs.secret-scan.outputs.scope }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.repository }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  INFISICAL_VERSION: "0.43.129"
+  INFISICAL_LINUX_AMD64_SHA256: "b829a04e10f1720b523aa81541f37ab479fbb4027a4a1af219f473d8c509e994"
+
+jobs:
+  secret-scan:
+    name: Scan Git history for secrets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      result: ${{ steps.scan.outputs.result }}
+      scope: ${{ steps.scope.outputs.scope }}
+
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Use trusted secret-scanning policy for pull requests
+        id: policy
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          policy_changed=false
+
+          for path in ".infisical-scan.toml" ".infisicalignore"; do
+            if ! git diff --quiet "$BASE_SHA" -- "$path"; then
+              policy_changed=true
+              echo "::warning title=Secret-scanning policy changed::$path is changed by this pull request. The scan will use the base branch version so the PR cannot weaken its own secret-scanning policy."
+            fi
+
+            rm -rf -- "$path"
+
+            if git cat-file -e "${BASE_SHA}:${path}" 2>/dev/null; then
+              git show "${BASE_SHA}:${path}" > "$path"
+            fi
+          done
+
+          echo "changed=$policy_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Determine scan scope
+        id: scope
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CURRENT_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          set -Eeuo pipefail
+
+          scope="full-history"
+          log_opts="--all"
+
+          commit_exists() {
+            local sha="$1"
+            [[ -n "$sha" ]] && git cat-file -e "${sha}^{commit}" 2>/dev/null
+          }
+
+          if [[ "$EVENT_NAME" == "pull_request" ]] &&
+             commit_exists "$PR_BASE_SHA" &&
+             commit_exists "$PR_HEAD_SHA"; then
+            scope="pull-request-diff"
+            log_opts="${PR_BASE_SHA}..${PR_HEAD_SHA}"
+          elif [[ "$EVENT_NAME" == "push" ]] &&
+               [[ -n "$PUSH_BEFORE_SHA" ]] &&
+               [[ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]] &&
+               commit_exists "$PUSH_BEFORE_SHA" &&
+               commit_exists "$CURRENT_SHA"; then
+            scope="push-diff"
+            log_opts="${PUSH_BEFORE_SHA}..${CURRENT_SHA}"
+          fi
+
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
+          echo "log_opts=$log_opts" >> "$GITHUB_OUTPUT"
+
+      - name: Install pinned Infisical CLI
+        id: install
+        shell: bash
+        env:
+          VERSION: ${{ env.INFISICAL_VERSION }}
+          EXPECTED_SHA256: ${{ env.INFISICAL_LINUX_AMD64_SHA256 }}
+        run: |
+          set -Eeuo pipefail
+
+          if [[ "$(uname -m)" != "x86_64" ]]; then
+            echo "::error title=Unsupported runner architecture::This workflow currently pins the Infisical linux_amd64 release asset."
+            exit 1
+          fi
+
+          archive="$RUNNER_TEMP/infisical.tar.gz"
+          extract_dir="$RUNNER_TEMP/infisical-extract"
+          binary="$RUNNER_TEMP/infisical"
+          url="https://github.com/Infisical/cli/releases/download/v${VERSION}/cli_${VERSION}_linux_amd64.tar.gz"
+
+          mkdir -p "$extract_dir"
+
+          curl \
+            --fail \
+            --show-error \
+            --silent \
+            --location \
+            --retry 3 \
+            --retry-all-errors \
+            --proto '=https' \
+            --tlsv1.2 \
+            "$url" \
+            --output "$archive"
+
+          printf '%s  %s\n' "$EXPECTED_SHA256" "$archive" | sha256sum --check --strict
+
+          tar -xzf "$archive" -C "$extract_dir"
+
+          extracted_binary="$(find "$extract_dir" -maxdepth 2 -type f -name infisical -print -quit)"
+          if [[ -z "$extracted_binary" ]]; then
+            echo "::error title=Invalid Infisical archive::Expected infisical binary was not found."
+            exit 1
+          fi
+
+          install -m 0755 "$extracted_binary" "$binary"
+          "$binary" --version
+
+          echo "binary=$binary" >> "$GITHUB_OUTPUT"
+
+      - name: Scan for leaked secrets
+        id: scan
+        shell: bash
+        env:
+          INFISICAL_BIN: ${{ steps.install.outputs.binary }}
+          LOG_OPTS: ${{ steps.scope.outputs.log_opts }}
+          SCAN_SCOPE: ${{ steps.scope.outputs.scope }}
+          EVENT_NAME: ${{ github.event_name }}
+          POLICY_CHANGED: ${{ steps.policy.outputs.changed }}
+        run: |
+          set -Eeuo pipefail
+
+          report="$RUNNER_TEMP/infisical-secret-scan.sarif"
+          leak_exit_code=42
+
+          args=(
+            scan
+            --redact
+            --no-color
+            --exit-code "$leak_exit_code"
+            --max-target-megabytes 20
+            --report-format sarif
+            --report-path "$report"
+            --log-opts "$LOG_OPTS"
+          )
+
+          set +e
+          "$INFISICAL_BIN" "${args[@]}"
+          scan_exit_code=$?
+          set -e
+
+          if [[ "$scan_exit_code" -eq 0 ]]; then
+            result="clean"
+          elif [[ "$scan_exit_code" -eq "$leak_exit_code" ]]; then
+            result="findings"
+          else
+            result="tool-failure"
+          fi
+
+          report_created=false
+          if [[ -s "$report" ]]; then
+            report_created=true
+          fi
+
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+          echo "report=$report" >> "$GITHUB_OUTPUT"
+          echo "report_created=$report_created" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Secret scan"
+            echo
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Scanner | Infisical CLI $INFISICAL_VERSION |"
+            echo "| Scope | $SCAN_SCOPE |"
+            echo "| Result | $result |"
+            if [[ "$EVENT_NAME" == "pull_request" && "$POLICY_CHANGED" == "true" ]]; then
+              echo "| Policy | Base branch policy used; PR changes to scanner suppressions/configuration were not trusted for this run |"
+            fi
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          case "$result" in
+            clean)
+              echo "No leaked secrets were detected in the selected Git range." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            findings)
+              {
+                echo "> [!CAUTION]"
+                echo "> Potential leaked secrets were detected. Revoke or rotate exposed credentials first, then remove them from code/history as appropriate. Do not suppress a real credential with an ignore rule."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error title=Potential secret exposure::Infisical detected one or more potential leaked secrets. Review the redacted report."
+              ;;
+            tool-failure)
+              {
+                echo "> [!WARNING]"
+                echo "> The scanner did not complete successfully. Treat this as a tooling failure, not as proof that the repository is clean."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "::error title=Secret scanner failure::Infisical exited unexpectedly with code $scan_exit_code."
+              ;;
+          esac
+
+      - name: Upload redacted SARIF report
+        if: always() && steps.scan.outputs.report_created == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: secret-scan-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.scan.outputs.report }}
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Enforce secret-scan result
+        if: always()
+        shell: bash
+        env:
+          RESULT: ${{ steps.scan.outputs.result }}
+        run: |
+          set -Eeuo pipefail
+
+          case "$RESULT" in
+            clean)
+              exit 0
+              ;;
+            findings)
+              echo "Secret findings must be reviewed and remediated before this check can pass."
+              exit 1
+              ;;
+            *)
+              echo "Secret scanning failed or did not produce a trustworthy result."
+              exit 2
+              ;;
+          esac

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Repository-specific files always take precedence when a project needs different 
 | [`.github/FUNDING.yml`](.github/FUNDING.yml) | GitHub Sponsors configuration. |
 | [`.github/workflows/dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) | Central automation that checks repository-root `global.json` files and opens SDK update Pull Requests when appropriate. |
 | [`.github/workflows/dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) | Central read-only automation that inventories .NET projects across repositories accessible to the configured GitHub App. |
+| [`.github/workflows/reusable-secret-scan.yml`](.github/workflows/reusable-secret-scan.yml) | Reusable, language-agnostic Git-history secret scanning policy for .NET and future stacks such as Node.js, React, Java, Python, Go, Terraform, Kubernetes, and Docker. |
 
 ## How GitHub uses this repository
 
@@ -99,6 +100,32 @@ Both files are uploaded as the `dotnet-repository-inventory` artifact with `rete
 
 Repositories without `.csproj` files are counted and do not fail the run. Clone or inspection problems in individual reported repositories are recorded as warnings/status entries, and the consolidated report is still produced. The workflow uses the existing GitHub App credentials, requests only read permissions from GitHub Actions, ignores forks and archived repositories, inspects default branches only, removes per-repository temporary directories after inspection, and does not write to analyzed repositories.
 
+## Reusable security automation
+
+### Secret scanning
+
+The [`reusable-secret-scan.yml`](.github/workflows/reusable-secret-scan.yml) workflow provides a reusable secret-scanning baseline that is intentionally independent of application language or build system.
+
+It scans Git history with the Infisical CLI and is suitable for .NET repositories as well as Node.js/React, Java/JVM, Python, Go, Terraform, Kubernetes, Docker, CI/CD configuration, and future technology stacks.
+
+Its security policy is intentionally conservative:
+
+- requests only `contents: read` from GitHub Actions;
+- does not require repository secrets and never builds or executes application code;
+- avoids `pull_request_target` and disables persisted checkout credentials;
+- checks out full Git history so committed credentials can be detected beyond the current working tree;
+- pins GitHub Actions dependencies to immutable commit SHAs;
+- downloads a fixed Infisical CLI version and verifies its SHA-256 checksum before execution;
+- redacts detected values from scanner output;
+- scans only the relevant PR or push commit range when trustworthy and falls back to full-history scanning otherwise;
+- treats both detected secrets and scanner/tool failures as failing checks;
+- stores only a redacted SARIF report and retains it for 3 days;
+- prevents a Pull Request from weakening its own `.infisical-scan.toml` or `.infisicalignore` policy by using the base-branch versions during that PR scan.
+
+False positives should be narrowly reviewed before adding fingerprints or exclusions. A real credential must be revoked or rotated first; ignore rules are not an acceptable remediation for an exposed secret.
+
+Repositories can adopt the policy through a small caller workflow that references this reusable workflow with `workflow_call`. See [`docs/secret-scanning.md`](docs/secret-scanning.md) for adoption examples, supported scenarios, false-positive handling, and incident-response guidance.
+
 ## Repository structure
 
 ```text
@@ -108,9 +135,13 @@ Repositories without `.csproj` files are counted and do not fail the run. Clone 
 │   ├── FUNDING.yml
 │   └── workflows/
 │       ├── dotnet-repository-inventory.yml
-│       └── dotnet-sdk-sync.yml
+│       ├── dotnet-sdk-sync.yml
+│       └── reusable-secret-scan.yml
 ├── .github.code-workspace
 ├── .gitignore
+├── docs/
+│   ├── secret-scanning.md
+│   └── secret-scanning.pt-BR.md
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 ├── README.md
@@ -125,6 +156,7 @@ This repository follows a few simple governance principles:
 - **least privilege** — cross-repository automation uses a GitHub App with scoped permissions;
 - **review before change** — maintenance automation opens Pull Requests instead of merging directly;
 - **safe defaults** — version-management automation avoids implicit major/minor migrations;
+- **defense in depth** — reusable security checks complement repository-specific controls and GitHub-native security features;
 - **observable automation** — workflow results are exposed through GitHub Actions logs, summaries, and short-lived artifacts when structured data is useful.
 
 ## Contributing

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -25,6 +25,7 @@ Arquivos específicos de cada repositório sempre têm prioridade quando um proj
 | [`.github/FUNDING.yml`](.github/FUNDING.yml) | Configuração do GitHub Sponsors. |
 | [`.github/workflows/dotnet-sdk-sync.yml`](.github/workflows/dotnet-sdk-sync.yml) | Automação central que verifica arquivos `global.json` na raiz dos repositórios e abre Pull Requests de atualização do SDK quando aplicável. |
 | [`.github/workflows/dotnet-repository-inventory.yml`](.github/workflows/dotnet-repository-inventory.yml) | Automação central somente leitura que inventaria projetos .NET nos repositórios acessíveis à GitHub App configurada. |
+| [`.github/workflows/reusable-secret-scan.yml`](.github/workflows/reusable-secret-scan.yml) | Política reutilizável e agnóstica de linguagem para análise de secrets no histórico Git, aplicável a .NET e também a stacks futuras como Node.js, React, Java, Python, Go, Terraform, Kubernetes e Docker. |
 
 ## Como o GitHub utiliza este repositório
 
@@ -99,6 +100,32 @@ Os dois arquivos são enviados como artifact `dotnet-repository-inventory` com `
 
 Repositórios sem arquivos `.csproj` são contabilizados e não fazem a execução falhar. Problemas de clone ou inspeção em repositórios individuais reportados são registrados como warnings/status, e o relatório consolidado continua sendo produzido. O workflow reutiliza as credenciais existentes da GitHub App, solicita apenas permissões de leitura no GitHub Actions, ignora forks e repositórios arquivados, inspeciona somente a branch padrão, remove diretórios temporários de cada repositório após a inspeção e não escreve nos repositórios analisados.
 
+## Automação reutilizável de segurança
+
+### Análise de secrets
+
+O workflow [`reusable-secret-scan.yml`](.github/workflows/reusable-secret-scan.yml) fornece uma base reutilizável para análise de secrets, deliberadamente independente da linguagem da aplicação ou do sistema de build.
+
+Ele analisa o histórico Git com o Infisical CLI e pode ser usado tanto em repositórios .NET quanto em Node.js/React, Java/JVM, Python, Go, Terraform, Kubernetes, Docker, configurações de CI/CD e outras stacks futuras.
+
+A política de segurança é deliberadamente conservadora:
+
+- solicita apenas `contents: read` ao GitHub Actions;
+- não exige secrets do repositório e nunca compila ou executa código da aplicação;
+- evita `pull_request_target` e desabilita a persistência das credenciais do checkout;
+- realiza checkout do histórico Git completo para detectar credenciais commitadas além da árvore de trabalho atual;
+- fixa as dependências do GitHub Actions em commit SHAs imutáveis;
+- baixa uma versão fixa do Infisical CLI e valida seu checksum SHA-256 antes da execução;
+- remove os valores detectados da saída do scanner;
+- analisa apenas o intervalo de commits relevante do PR ou push quando esse intervalo é confiável, utilizando histórico completo como fallback;
+- faz o check falhar tanto quando encontra possíveis secrets quanto quando o scanner não conclui de forma confiável;
+- armazena apenas um relatório SARIF com valores ocultos e retenção de 3 dias;
+- impede que um Pull Request enfraqueça sua própria política em `.infisical-scan.toml` ou `.infisicalignore`, usando durante o scan as versões existentes na branch base.
+
+Falsos positivos devem ser revisados individualmente antes da inclusão de fingerprints ou exclusões. Uma credencial real deve primeiro ser revogada ou rotacionada; adicionar uma regra de ignore não é uma correção válida para um secret exposto.
+
+Os repositórios podem adotar essa política através de um pequeno caller workflow que referencia este workflow reutilizável por `workflow_call`. Consulte [`docs/secret-scanning.pt-BR.md`](docs/secret-scanning.pt-BR.md) para exemplos de adoção, cenários suportados, tratamento de falsos positivos e orientações de resposta a incidentes.
+
 ## Estrutura do repositório
 
 ```text
@@ -108,9 +135,13 @@ Repositórios sem arquivos `.csproj` são contabilizados e não fazem a execuç�
 │   ├── FUNDING.yml
 │   └── workflows/
 │       ├── dotnet-repository-inventory.yml
-│       └── dotnet-sdk-sync.yml
+│       ├── dotnet-sdk-sync.yml
+│       └── reusable-secret-scan.yml
 ├── .github.code-workspace
 ├── .gitignore
+├── docs/
+│   ├── secret-scanning.md
+│   └── secret-scanning.pt-BR.md
 ├── CONTRIBUTING.md
 ├── SECURITY.md
 ├── README.md
@@ -125,6 +156,7 @@ Este repositório segue alguns princípios simples:
 - **menor privilégio** — automações entre repositórios usam uma GitHub App com permissões restritas;
 - **revisão antes da alteração** — automações de manutenção abrem Pull Requests em vez de fazer merge direto;
 - **padrões seguros** — a automação de versões não realiza migrações implícitas de major/minor;
+- **defesa em profundidade** — checks reutilizáveis de segurança complementam controles específicos de cada repositório e os recursos de segurança nativos do GitHub;
 - **automação observável** — os resultados dos workflows são registrados nos logs, summaries e artifacts de curta duração quando dados estruturados são úteis.
 
 ## Contribuição

--- a/docs/secret-scanning.md
+++ b/docs/secret-scanning.md
@@ -1,0 +1,169 @@
+# Reusable secret scanning
+
+> 🇧🇷 [Leia em Português](secret-scanning.pt-BR.md)
+
+The [`reusable-secret-scan.yml`](../.github/workflows/reusable-secret-scan.yml) workflow provides a central secret-detection policy for repositories maintained under this account.
+
+It is intentionally language- and framework-agnostic. Scanning operates on Git history and does not require build, restore, dependency installation, or execution of repository code. The same policy can therefore be applied to .NET, Node.js, React, Java, Python, Go, Terraform, and future stacks.
+
+## Security goals
+
+The implementation follows these principles:
+
+- **least privilege** — the `GITHUB_TOKEN` receives only `contents: read`;
+- **no repository secret is required** to run the scanner;
+- **no `pull_request_target`** — pull requests use the normal unprivileged GitHub Actions context;
+- **repository code is not executed** — there is no `dotnet build`, `npm install`, Maven, Gradle, project script, or hook execution;
+- **complete Git history is available** — `fetch-depth: 0` allows commit ranges to be scanned correctly;
+- **checkout credentials are not persisted** — `persist-credentials: false`;
+- **GitHub Actions are pinned to immutable commit SHAs** to reduce tag-mutation risk;
+- **the Infisical CLI is pinned to a specific version** and downloaded directly from its official release;
+- **the binary SHA-256 is verified before execution**;
+- **output is redacted** with `--redact`, avoiding disclosure of detected secret values;
+- **fail closed** — both findings and scanner/tool failures invalidate the check;
+- **short-lived artifacts** — the redacted SARIF report is retained for only 3 days.
+
+This workflow complements rather than replaces GitHub Secret Scanning and Push Protection. GitHub's native protection can also scan surfaces a CI job cannot cover, including issue, pull-request, Discussion, and wiki content.
+
+## Scan scope
+
+The workflow automatically chooses the smallest safe scope for each event:
+
+| Event | Scope |
+| --- | --- |
+| `pull_request` | commits introduced by the PR (`base..head`) |
+| `push` | commits introduced by the push (`before..after`) |
+| `workflow_dispatch`, `schedule`, or a context without a trustworthy range | full history (`--all`) |
+
+This avoids performing a full repository scan for every pull request while preserving the ability to run complete periodic or manual audits.
+
+If the expected range is unavailable locally, the workflow falls back to **full-history**, never to a weaker scan.
+
+## Protecting the scanner policy from the pull request itself
+
+Two files can alter local Infisical behavior:
+
+- `.infisical-scan.toml`;
+- `.infisicalignore`.
+
+On a pull request these files are treated as **privileged security policy**. If the PR changes either file, the workflow:
+
+1. emits a visible warning;
+2. temporarily restores the version from the base branch;
+3. runs the scan with that trusted policy.
+
+This prevents a pull request from adding a secret and suppressing the same finding in the same diff.
+
+After a legitimate policy change is reviewed and merged, it becomes effective for subsequent scans.
+
+## Using it from another repository
+
+Create a small caller workflow in the consuming repository, for example `.github/workflows/secret-scan.yml`:
+
+```yaml
+name: Secret scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 11 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    uses: rodri-oliveira-dev/.github/.github/workflows/reusable-secret-scan.yml@main
+```
+
+For stronger supply-chain isolation, external consumers or repositories with stricter requirements can replace `@main` with an immutable commit SHA of the central workflow. For repositories maintained by the same account, `@main` allows central policy fixes to propagate without duplicating YAML.
+
+## Stack coverage
+
+The scanner does not depend on an extension allowlist. Versioned files are analyzed using Infisical patterns and heuristics, including common cases such as the following.
+
+### .NET
+
+- `appsettings.json` and `appsettings.*.json`;
+- `launchSettings.json`;
+- `NuGet.Config`;
+- connection strings;
+- NuGet API keys;
+- JWT signing keys;
+- Azure, AWS, and GCP credentials;
+- certificates and private keys.
+
+### Node.js / React / front-end
+
+- `.env`, `.env.*`, and equivalent environment files;
+- `.npmrc`;
+- npm tokens;
+- API keys used by build scripts;
+- third-party service credentials;
+- private keys or certificates.
+
+Variables intentionally delivered to the browser bundle — for example framework variables explicitly marked public — **must not be treated as secret storage**. If a value reaches the client, it is public by architecture.
+
+### Java / JVM
+
+- `application.properties`;
+- `application.yml` / `application.yaml`;
+- `settings.xml`;
+- `gradle.properties`;
+- registry and artifact-repository credentials;
+- keystores, private keys, and cloud-provider tokens.
+
+### Python, Go, and other languages
+
+The same policy covers `.env` files, configuration files, hardcoded tokens, connection strings, cloud credentials, private keys, and other detectable patterns independently of the implementation language.
+
+### Infrastructure and CI/CD
+
+Relevant surfaces also include:
+
+- `*.tfvars` and Terraform configuration;
+- Kubernetes manifests and kubeconfig;
+- Docker / Compose configuration;
+- GitHub Actions workflows;
+- deployment configuration;
+- service-account keys;
+- Shell and PowerShell scripts.
+
+## False positives
+
+A finding should only be ignored after verifying that the value **does not grant real access**.
+
+Prefer specific fingerprints in `.infisicalignore` over broad directory or extension exclusions. Avoid generically ignoring files such as `appsettings*.json`, `.env*`, `application*.yml`, or CI/CD files because these are common exposure surfaces.
+
+Changes to `.infisicalignore` or `.infisical-scan.toml` should receive the same review rigor as any other security configuration change.
+
+Never use an ignore rule to "fix" a real exposed credential.
+
+## Responding to a real secret
+
+When the scanner identifies a real credential:
+
+1. **revoke or rotate the credential immediately**;
+2. remove the value from code and move it to the appropriate secret-management mechanism;
+3. review service logs and usage for signs of unauthorized use;
+4. determine whether Git-history removal is required;
+5. only then address preventive rules or documentation.
+
+Rewriting history without revoking the credential does not make an exposed credential safe again.
+
+## Optional repository-local configuration
+
+Repositories may add `.infisical-scan.toml` when they need specific rules or tuning. They may also use `.infisicalignore` for fingerprints of verified false positives.
+
+Local configuration should remain exceptional and restrictive: the central policy is designed to work without language-specific configuration.
+
+References:
+
+- [Infisical CLI secret scanning](https://infisical.com/docs/cli/commands/scan)
+- [Infisical secret scanning overview](https://infisical.com/docs/documentation/platform/secret-scanning/overview)
+- [GitHub Secret Scanning](https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning)
+- [GitHub Actions secure use](https://docs.github.com/en/actions/reference/security/secure-use)

--- a/docs/secret-scanning.pt-BR.md
+++ b/docs/secret-scanning.pt-BR.md
@@ -1,0 +1,169 @@
+# Secret scanning reutilizável
+
+> 🇺🇸 [Read in English](secret-scanning.md)
+
+O workflow [`reusable-secret-scan.yml`](../.github/workflows/reusable-secret-scan.yml) fornece uma política central de detecção de secrets para os repositórios mantidos nesta conta.
+
+Ele é deliberadamente independente de linguagem e framework. A análise ocorre sobre o histórico Git e não depende de build, restore, instalação de dependências ou execução do código do repositório. Isso permite aplicar a mesma política a projetos .NET, Node.js, React, Java, Python, Go, Terraform e outras stacks futuras.
+
+## Objetivos de segurança
+
+A implementação segue estes princípios:
+
+- **menor privilégio** — o `GITHUB_TOKEN` recebe apenas `contents: read`;
+- **nenhum secret do repositório é necessário** para executar o scanner;
+- **sem `pull_request_target`** — PRs utilizam o contexto não privilegiado normal do GitHub Actions;
+- **código do repositório não é executado** — não há `dotnet build`, `npm install`, Maven, Gradle, scripts de projeto ou hooks;
+- **histórico Git completo disponível** — `fetch-depth: 0` permite analisar ranges de commits corretamente;
+- **credenciais do checkout não persistem** — `persist-credentials: false`;
+- **actions fixadas por commit SHA imutável** para reduzir risco de alteração de tags;
+- **Infisical CLI fixado em uma versão específica** e baixado diretamente do release oficial;
+- **SHA-256 do binário é validado antes da execução**;
+- **saída é redigida** com `--redact`, evitando imprimir o valor detectado do secret;
+- **falha fechada** — tanto findings quanto falha da ferramenta tornam o check inválido;
+- **artifacts de curta duração** — o relatório SARIF redigido fica disponível por apenas 3 dias.
+
+O workflow complementa, e não substitui, o Secret Scanning e o Push Protection nativos do GitHub. A proteção nativa também consegue analisar superfícies que um job de CI não cobre, como conteúdo de issues, Pull Requests, Discussions e wikis.
+
+## Escopo da análise
+
+O workflow escolhe automaticamente o menor escopo seguro para cada evento:
+
+| Evento | Escopo |
+| --- | --- |
+| `pull_request` | commits introduzidos pelo PR (`base..head`) |
+| `push` | commits introduzidos pelo push (`before..after`) |
+| `workflow_dispatch`, `schedule` ou contexto sem range confiável | histórico completo (`--all`) |
+
+Isso evita repetir um full scan em cada PR sem perder a capacidade de fazer auditorias completas periódicas ou manuais.
+
+Se o range esperado não estiver disponível localmente, o comportamento degrada para **full-history**, nunca para um scan mais fraco.
+
+## Proteção contra alteração da própria política
+
+Dois arquivos podem alterar o comportamento local do Infisical:
+
+- `.infisical-scan.toml`;
+- `.infisicalignore`.
+
+Em um Pull Request, esses arquivos são tratados como **dados de segurança privilegiados**. Se o PR alterá-los, o workflow:
+
+1. emite um warning visível;
+2. restaura temporariamente a versão existente na branch base;
+3. executa o scan usando essa política confiável.
+
+Assim, um PR não consegue adicionar um secret e, no mesmo diff, adicionar uma regra de ignore para esconder o finding.
+
+Depois que uma mudança legítima de política for revisada e mergeada, ela passa a valer normalmente nos próximos scans.
+
+## Uso em outro repositório
+
+Crie um caller pequeno no repositório consumidor, por exemplo `.github/workflows/secret-scan.yml`:
+
+```yaml
+name: Secret scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 11 * * 3"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    uses: rodri-oliveira-dev/.github/.github/workflows/reusable-secret-scan.yml@main
+```
+
+Para maior isolamento de supply chain, consumidores externos ou repositórios com exigência mais rígida podem substituir `@main` por um commit SHA imutável do workflow central. Nos repositórios mantidos pela própria conta, usar `@main` permite receber correções da política central sem duplicar YAML.
+
+## Cobertura por stack
+
+O scanner não depende de uma lista de extensões. Arquivos versionados são analisados pelos padrões e heurísticas do Infisical, incluindo casos comuns como:
+
+### .NET
+
+- `appsettings.json` e `appsettings.*.json`;
+- `launchSettings.json`;
+- `NuGet.Config`;
+- connection strings;
+- NuGet API keys;
+- JWT signing keys;
+- Azure, AWS e GCP credentials;
+- certificados e private keys.
+
+### Node.js / React / front-end
+
+- `.env`, `.env.*` e arquivos equivalentes;
+- `.npmrc`;
+- npm tokens;
+- API keys usadas em scripts de build;
+- credenciais de serviços externos;
+- chaves privadas ou certificados.
+
+Variáveis destinadas ao bundle do navegador — por exemplo variáveis explicitamente públicas de frameworks front-end — **não devem ser tratadas como mecanismo de armazenamento de secrets**. Se o valor chega ao cliente, deve ser considerado público por arquitetura.
+
+### Java / JVM
+
+- `application.properties`;
+- `application.yml` / `application.yaml`;
+- `settings.xml`;
+- `gradle.properties`;
+- credenciais de registries e artifact repositories;
+- keystores, private keys e tokens de cloud providers.
+
+### Python, Go e outras linguagens
+
+A mesma política cobre `.env`, arquivos de configuração, tokens hardcoded, connection strings, credenciais cloud, private keys e outros padrões detectáveis, independentemente da linguagem do código.
+
+### Infraestrutura e CI/CD
+
+Também são relevantes:
+
+- `*.tfvars` e Terraform configuration;
+- Kubernetes manifests e kubeconfig;
+- Docker / Compose configuration;
+- GitHub Actions workflows;
+- arquivos de configuração de deploy;
+- service-account keys;
+- scripts Shell e PowerShell.
+
+## Falsos positivos
+
+Um finding só deve ser ignorado depois de verificar que o valor **não concede acesso real**.
+
+Prefira fingerprints específicos em `.infisicalignore` a exclusões amplas por diretório ou extensão. Evite ignorar genericamente arquivos como `appsettings*.json`, `.env*`, `application*.yml` ou arquivos de CI/CD, pois eles são justamente superfícies frequentes de exposição.
+
+Mudanças em `.infisicalignore` ou `.infisical-scan.toml` devem receber o mesmo nível de revisão que uma alteração em configuração de segurança.
+
+Nunca use uma regra de ignore para "resolver" uma credencial real exposta.
+
+## Resposta a um secret real
+
+Quando o scanner detectar uma credencial verdadeira:
+
+1. **revogue ou rotacione a credencial imediatamente**;
+2. remova o valor do código e mova-o para o mecanismo apropriado de secret management;
+3. revise logs e uso do serviço para procurar utilização indevida;
+4. determine se é necessário remover o valor do histórico Git;
+5. somente depois trate eventuais regras de prevenção ou documentação.
+
+Reescrever o histórico sem revogar a credencial não torna uma credencial exposta novamente segura.
+
+## Configuração local opcional
+
+Repositórios podem adicionar `.infisical-scan.toml` quando precisarem de regras ou ajustes específicos. Também podem utilizar `.infisicalignore` para fingerprints de falsos positivos conhecidos.
+
+A configuração local deve permanecer excepcional e restritiva: a política central busca funcionar sem configuração específica por linguagem.
+
+Referências:
+
+- [Infisical CLI secret scanning](https://infisical.com/docs/cli/commands/scan)
+- [Infisical secret scanning overview](https://infisical.com/docs/documentation/platform/secret-scanning/overview)
+- [GitHub Secret Scanning](https://docs.github.com/en/code-security/concepts/secret-security/secret-scanning)
+- [GitHub Actions secure use](https://docs.github.com/en/actions/reference/security/secure-use)


### PR DESCRIPTION
## Summary

Adds a reusable, language-agnostic secret scanning workflow designed for the repositories maintained under this account.

### Security design

- uses only `contents: read`;
- does not require repository secrets;
- avoids `pull_request_target`;
- never builds or executes repository/application code;
- checks out full Git history with credentials disabled after checkout;
- pins `actions/checkout` and `actions/upload-artifact` to immutable commit SHAs;
- downloads the official Infisical CLI at a fixed version and verifies the release SHA-256 before execution;
- uses redacted output and a 3-day SARIF artifact retention;
- fails closed on both detected secrets and scanner/tool failures;
- scans only the PR/push commit range when trustworthy, falling back to full history when it is not;
- prevents a PR from weakening its own `.infisical-scan.toml` or `.infisicalignore` policy by scanning with the base-branch versions of those files.

### Stack coverage

The policy is intentionally independent of project type and applies to .NET, Node.js/React, Java/JVM, Python, Go, Terraform, Kubernetes, Docker, CI/CD configuration, and future stacks without language-specific workflow duplication.

### Documentation

Adds English and PT-BR adoption/security guidance, including false-positive handling and incident-response expectations.

## Validation

- reviewed the final diff against `main`;
- workflow YAML parses successfully;
- every Bash `run` block passes `bash -n` syntax validation;
- pinned Infisical `v0.43.129` linux/amd64 release asset checksum matches the official GitHub release metadata.

Runtime execution can be exercised through `workflow_dispatch` once the reusable workflow is available from the default branch.