### PR TITLE
fix(agent-governance): preserve distribution workflow exit status

### DIFF
--- a/.github/workflows/distribute-agent-skills.yml
+++ b/.github/workflows/distribute-agent-skills.yml
@@ -73,9 +73,15 @@ jobs:
           cleanup_paths=("$repositories_file")
 
           cleanup() {
+            local exit_code=$?
+            local path
+
+            trap - EXIT
             for path in "${cleanup_paths[@]}"; do
-              [[ -e "$path" ]] && rm -rf "$path"
+              rm -rf -- "$path" || true
             done
+
+            return "$exit_code"
           }
           trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

Fixes the false-negative failure observed in the `Distribute managed agent skills` workflow after PR #7 was merged.

## Root cause

The distribution script runs with `set -Eeuo pipefail` and registers an `EXIT` cleanup trap. Temporary files are also removed during normal execution. At process exit, the cleanup function re-checked paths with:

```bash
[[ -e "$path" ]] && rm -rf "$path"
```

When the last tracked path had already been removed, the test returned status `1`. Because that status became the cleanup function's return status, the workflow finished with exit code `1` even though there was no GitHub App, API, clone, push, or PR-creation error.

## Fix

The cleanup function now:

- captures the original process exit status;
- disables the `EXIT` trap before cleanup;
- removes tracked paths idempotently with `rm -rf -- ... || true`;
- returns the original exit status after cleanup.

This prevents cleanup from turning a successful distribution run into a failure while still preserving real failures from the main workflow body.

## Scope

One workflow file only:

- `.github/workflows/distribute-agent-skills.yml`

No change to skill mappings, repository discovery, permissions, GitHub App configuration, distribution policy, branch naming, or PR behavior.

## Validation

- branch is based directly on current `main`;
- exactly one commit ahead;
- exactly one file changed;
- diff is limited to the cleanup function.

The existing `Agent governance validation` workflow is expected to run on this PR.