### PR TITLE
chore(agent-governance): self-trigger distributor workflow changes

### DIFF
--- a/.github/workflows/distribute-agent-skills.yml
+++ b/.github/workflows/distribute-agent-skills.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/distribute-agent-skills.yml"
       - "agent-governance/skills/dotnet/dotnet-issue-implementation/**"
       - "agent-governance/skills/dotnet/dotnet-bug-investigation/**"
       - "agent-governance/skills/dotnet/dotnet-pr-review/**"


### PR DESCRIPTION
## Summary

Ensures changes to the distributor workflow itself trigger a new `Distribute managed agent skills` run after merge to `main`.

## Change

Adds the workflow file itself to the `push.paths` filter:

```yaml
.github/workflows/distribute-agent-skills.yml
```

The existing managed-skill paths remain unchanged.

## Why

The cleanup bug fixed in PR #8 was merged successfully, but the distributor workflow did not run again because its own file was not part of the trigger paths. As a result, the README badge continued showing the previous failed run.

With this change, future maintenance or bug fixes to `distribute-agent-skills.yml` will automatically exercise the workflow on `main`, so its status badge reflects the current implementation instead of an older run.

## Scope

- 1 commit
- 1 file changed
- 1 line added
- no changes to skill mappings, permissions, GitHub App configuration, repository discovery, PR behavior, or auto-merge policy

## Validation

The branch is based on current `main` (`2c4d507d848150310bf5e372e168687408ecf049`) and is exactly one commit ahead with no drift from the base branch.