### PR TITLE
docs: document GitHub API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ Examples of repository-specific overrides include:
 - build, testing, release, or compatibility requirements;
 - repository-specific agent instructions and skills.
 
+## GitHub API integration
+
+This repository also acts as a control plane for integrations built on a GitHub App and the GitHub REST API. Maintenance workflows authenticate with short-lived installation tokens and use scoped API operations to discover repositories, read repository metadata and contents, create or update branches, and open reviewable Pull Requests.
+
+Current API-backed integrations include:
+
+- `.NET SDK synchronization`, which discovers repositories, reads `global.json`, creates update branches, writes eligible SDK changes, and opens Pull Requests;
+- managed agent-skill distribution, which inspects consumer repositories and creates or refreshes Pull Requests when approved central skills drift;
+- `.NET repository inventory`, which uses the GitHub App as a read-only discovery boundary before repository inspection.
+
+The integration model follows least privilege: GitHub App permissions are scoped to each workflow's needs, writes are review-gated through Pull Requests, and read-only workflows do not modify inspected repositories.
+
 ## Central .NET automations
 
 ### .NET SDK synchronization

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -52,6 +52,18 @@ Exemplos de regras que podem ser sobrescritas localmente:
 - requisitos de build, testes, release ou compatibilidade;
 - instruções e skills específicas de agentes do repositório.
 
+## Integração com a API do GitHub
+
+Este repositório também atua como um control plane para integrações construídas sobre uma GitHub App e a GitHub REST API. Os workflows de manutenção se autenticam com tokens de instalação de curta duração e utilizam operações de API com escopo restrito para descobrir repositórios, ler metadados e conteúdos, criar ou atualizar branches e abrir Pull Requests revisáveis.
+
+As integrações atuais baseadas na API incluem:
+
+- sincronização do `.NET SDK`, que descobre repositórios, lê `global.json`, cria branches de atualização, grava alterações elegíveis de SDK e abre Pull Requests;
+- distribuição de skills gerenciadas de agentes, que inspeciona repositórios consumidores e cria ou atualiza Pull Requests quando as skills centrais aprovadas apresentam drift;
+- inventário de repositórios `.NET`, que usa a GitHub App como fronteira de descoberta somente leitura antes da inspeção dos projetos.
+
+O modelo de integração segue o princípio de menor privilégio: as permissões da GitHub App são restritas às necessidades de cada workflow, alterações são controladas por revisão através de Pull Requests e workflows somente leitura não modificam os repositórios inspecionados.
+
 ## Automações centrais de .NET
 
 ### Sincronização central do .NET SDK


### PR DESCRIPTION
## Summary

- documents the GitHub App and GitHub REST API integration used by the central maintenance automations;
- identifies the API-backed SDK synchronization, agent-skill distribution, and repository inventory flows;
- makes the least-privilege and review-gated integration model explicit;
- keeps the documentation aligned in English and Portuguese.

## Motivation

The repository already operates as a control plane for cross-repository automation through a GitHub App. Making that integration explicit improves the repository documentation and provides a clear public description of how the GitHub API is used.